### PR TITLE
Upgrade rbsecp256k1 dep to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'keccak', '~> 1.2'
-gem 'rbsecp256k1', '~> 5.0'
+gem 'rbsecp256k1', '~> 5.1.0'
 
 group :test, :development do
   gem 'bundler', '~> 2.2'


### PR DESCRIPTION
`rbsecp256k1` was not compiling on m1 macs. We fixed one of their downstream deps here: https://github.com/etscrivner/rbsecp256k1/pull/55. The maintainer released a new gem version with the fix.

This PR upgrades rbsecp256k1 to the latest gem.