### PR TITLE
gems: bump keccak and secp256k1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@
 
 source 'https://rubygems.org'
 
-gem 'keccak', '~> 1.2'
-gem 'rbsecp256k1', '~> 5.0'
+gem 'keccak', '~> 1.3'
+gem 'rbsecp256k1', '~> 5.1'
 
 group :test, :development do
   gem 'bundler', '~> 2.2'

--- a/lib/eth/utils.rb
+++ b/lib/eth/utils.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'digest/sha3'
+require 'digest/keccak'
 
 module Eth
 
@@ -30,7 +30,7 @@ module Eth
     # @param str [String] a string to be hashed.
     # @return [String] a Keccak-256 hash of the given string.
     def keccak256 str
-      Digest::SHA3.new(256).digest str
+      Digest::Keccak.new(256).digest str
     end
 
     # Unpacks a binary string to a hexa-decimal string.


### PR DESCRIPTION
bump `keccak` to 1.3.0; rename `::SHA3` to `::Keccak`
* ref https://github.com/q9f/keccak.rb/pull/16

bump `rbsecp256k1` to 5.1.0 to address M1 silicon issues
* ref https://github.com/etscrivner/rbsecp256k1/pull/55