### PR TITLE
Address class implementation and tests

### DIFF
--- a/lib/eth.rb
+++ b/lib/eth.rb
@@ -18,5 +18,6 @@ end
 
 # Loads the `Eth` module classes.
 require 'eth/key'
+require 'eth/address'
 require 'eth/utils'
 require 'eth/version'

--- a/lib/eth/address.rb
+++ b/lib/eth/address.rb
@@ -1,0 +1,85 @@
+# Copyright (c) 2016-2022 The Ruby-Eth Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Eth
+  
+  class Address
+
+    attr_reader :address
+
+    # Constructor of the `Eth::Address` class. Creates a new hex
+    # prefixed address
+    #
+    # @param address [String] hex string representing an ethereum address.
+    def initialize address
+      @address = Utils.prefix_hex address
+    end
+
+    # Check that the address is valid
+    #
+    # @return [Bool]
+    def valid?
+      if !matches_any_format?
+        false
+      elsif not_checksummed?
+        true
+      else
+        checksum_matches?
+      end
+    end
+
+    # Generate a checksummed address
+    #
+    # @return address [String] prefixed hex string representing an checksummed address.
+    def checksummed
+      raise "Invalid address: #{address}" unless matches_any_format?
+
+      cased = unprefixed.chars.zip(checksum.chars).map do |char, check|
+        check.match(/[0-7]/) ? char.downcase : char.upcase
+      end
+
+      Utils.prefix_hex(cased.join)
+    end
+
+    private
+
+    def checksum_matches?
+      address == checksummed
+    end
+
+    def not_checksummed?
+      all_uppercase? || all_lowercase?
+    end
+
+    def all_uppercase?
+      address.match(/(?:0[xX])[A-F0-9]{40}/)
+    end
+
+    def all_lowercase?
+      address.match(/(?:0[xX])[a-f0-9]{40}/)
+    end
+
+    def matches_any_format?
+      address.match(/\A(?:0[xX])[a-fA-F0-9]{40}\z/)
+    end
+
+    def checksum
+      Utils.bin_to_hex(Utils.keccak256 unprefixed.downcase)
+    end
+
+    def unprefixed
+      Utils.remove_hex_prefix address
+    end
+  end
+end

--- a/lib/eth/key.rb
+++ b/lib/eth/key.rb
@@ -98,9 +98,11 @@ module Eth
       @public_key.compressed
     end
 
+    # Exports the checksummed public address.
+    #
+    # @return [String] compressed address as packed hex prefixed string.
     def address
-      # @TODO Checksummed addresses
-      Utils.public_key_to_address public_bytes
+      Eth::Address.new(Utils.public_key_to_address public_bytes)
     end
   end
 end

--- a/spec/eth/address_spec.rb
+++ b/spec/eth/address_spec.rb
@@ -1,0 +1,160 @@
+require 'spec_helper'
+
+describe Eth::Address do
+  describe ".initialize" do
+    # alice is initialized with an unprefixed address
+    subject(:alice) { Eth::Address.new "c1c0f155bd054597c60cb33e6da7edbc9c70275b" }
+    # bob is initialized with a prefixed address
+    subject(:bob) { Eth::Address.new "0x7291d3cd257053bac810ee2c55fd7c154bd455af" }
+
+    it "generates functional addresses" do
+
+      # generates a functional key for alice of type Eth::Address
+      expect(alice).to be_an_instance_of Eth::Address
+      expect(bob).to be_an_instance_of Eth::Address
+
+      # ensure both addresses are not the same
+      expect(alice.address).not_to eq bob.address
+    end
+
+    it "prefixes an unprefixed address" do
+
+      # ensure both addresses contains the 0x prefix
+      # alice's address was initialized without 0x
+      expect(alice.address).to start_with "0x"
+      expect(bob.address).to start_with "0x"
+    end
+  end
+
+  describe ".valid?" do
+    context "given an address with a valid checksum" do
+      let(:addresses) do
+        [
+          "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+          "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+          "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB",
+          "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+        ]
+      end
+
+      it "returns true" do
+        addresses.each do |address|
+          expect(Eth::Address.new address).to be_valid
+        end
+      end
+    end
+
+    context "given an address with an invalid checksum" do
+      let(:addresses) do
+        [
+          "0x5AAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+          "0xFB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+          "0xDbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB",
+          "0xd1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+        ]
+      end
+
+      it "returns false" do
+        addresses.each do |address|
+          expect(Eth::Address.new address).not_to be_valid
+        end
+      end
+    end
+
+    context "given an address with all uppercase letters" do
+      let(:addresses) do
+        [
+          "0x5AAEB6053F3E94C9B9A09F33669435E7EF1BEAED",
+          "0xFB6916095CA1DF60BB79CE92CE3EA74C37C5D359",
+          "0xDBF03B407C01E7CD3CBEA99509D93F8DDDC8C6FB",
+          "0xD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB",
+        # common EIP55 examples
+          "0x52908400098527886E0F7030069857D2E4169EE7",
+          "0x8617E340B3D01FA5F11F306F4090FD50E238070D",
+        ]
+      end
+
+      it "returns true" do
+        addresses.each do |address|
+          expect(Eth::Address.new address).to be_valid
+        end
+      end
+    end
+
+    context "given an address with all lowercase letters" do
+      let(:addresses) do
+        [
+          "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed",
+          "0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359",
+          "0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb",
+          "0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb",
+        # common EIP55 examples
+          '0xde709f2102306220921060314715629080e2fb77',
+          '0x27b1fdb04752bbc536007a920d24acb045561c26',
+        ]
+      end
+
+      it "returns true" do
+        addresses.each do |address|
+          expect(Eth::Address.new address).to be_valid
+        end
+      end
+    end
+
+    context "given an invalid address" do
+      let(:addresses) do
+        [
+          "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beae",
+          "0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359d",
+          "0x5AAEB6053F3E94C9B9A09F33669435E7EF1BEAE",
+          "0xFB6916095CA1DF60BB79CE92CE3EA74C37C5D359D",
+        ]
+      end
+
+      it "returns true" do
+        addresses.each do |address|
+          expect(Eth::Address.new address).not_to be_valid
+        end
+      end
+    end
+  end
+
+  describe ".checksummed" do
+    let(:addresses) do
+      [
+      # downcased
+        ["0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed", "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"],
+        ["0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359", "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"],
+        ["0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb", "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB"],
+        ["0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb", "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb"],
+      # upcased
+        ["0x5AAEB6053F3E94C9B9A09F33669435E7EF1BEAED", "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"],
+        ["0xFB6916095CA1DF60BB79CE92CE3EA74C37C5D359", "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"],
+        ["0xDBF03B407C01E7CD3CBEA99509D93F8DDDC8C6FB", "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB"],
+        ["0xD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB", "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb"],
+      # checksummed
+        ["0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed", "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"],
+        ["0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359", "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"],
+        ["0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB", "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB"],
+        ["0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb", "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb"],
+      ]
+    end
+
+    it "follows EIP55 standard" do
+      addresses.each do |plain, checksummed|
+        address = Eth::Address.new(plain)
+        expect(address.checksummed).to eq checksummed
+      end
+    end
+
+    context "given an invalid address" do
+      let(:bad) { "0x#{SecureRandom.hex(21)[0..40]}" }
+
+      it "raises an error" do
+        expect {
+          Eth::Address.new(bad).checksummed
+        }.to raise_error "Invalid address: #{bad}"
+      end
+    end
+  end
+end

--- a/spec/eth/key_spec.rb
+++ b/spec/eth/key_spec.rb
@@ -99,13 +99,10 @@ describe Eth::Key do
 
   describe ".address" do
     it "generates the correct address from key" do
-    #it "generates a checksummed address" do
       address = '0x759b427456623a33030bbC2195439C22A8a51d25'
       private_hex = 'c3a4349f6e57cfd2cbba275e3b3d15a2e4cf00c89e067f6e05bfee25208f9cbb'
       key = Eth::Key.new priv: private_hex
-      expect(key.address).to eq address.downcase
-      # @TODO Checksummed addresses
-      #expect(key.address).to eq address
+      expect(key.address.checksummed).to eq address
     end
   end
 end


### PR DESCRIPTION
The `Eth::Address` implementation contains two slight, yet important changes compared to the [original repo](https://github.com/se3000/ruby-eth/blob/develop/lib/eth/address.rb):

1. We are making `address` readable. The rationale is that a user could previously access `address` via the `checksummed` method, could check if an initialized `address` was `valid?`, but not access the initialized `address` itself. This leads to the next important change.
2. `Eth::Key::address` returns the entire `Eth::Address` object, rather than just a `checksummed` address hex. This is a breaking change compared to the original repo, but does give the user more visibility into the key/address relationship.