### PR TITLE
eth/util: public_key_to_address should return an eth::address

### DIFF
--- a/lib/eth/address.rb
+++ b/lib/eth/address.rb
@@ -55,6 +55,13 @@ module Eth
       Utils.prefix_hex(cased.join)
     end
 
+    # Generate a checksummed address string. Alias for `checksummed`.
+    #
+    # @return [String] prefixed hexstring representing an checksummed address.
+    def to_s
+      checksummed
+    end
+
     private
 
     def checksum_matches?

--- a/lib/eth/key.rb
+++ b/lib/eth/key.rb
@@ -100,9 +100,9 @@ module Eth
 
     # Exports the checksummed public address.
     #
-    # @return [String] compressed address as packed hex prefixed string.
+    # @return [Eth::Address] compressed address as packed hex prefixed string.
     def address
-      Eth::Address.new(Utils.public_key_to_address public_bytes)
+      Utils.public_key_to_address public_bytes
     end
   end
 end

--- a/lib/eth/utils.rb
+++ b/lib/eth/utils.rb
@@ -25,12 +25,11 @@ module Eth
     # uncompressed binary or hexadecimal public key string.
     #
     # @param str [String] the public key to be converted.
-    # @return [String] an Ethereum address.
+    # @return [Eth::Address] an Ethereum address.
     def public_key_to_address str
       str = hex_to_bin str if is_hex? str
       bytes = keccak256(str[1..-1])[-20..-1 ]
-      address = bin_to_prefixed_hex bytes
-      # @TODO Checksummed addresses
+      Eth::Address.new bin_to_prefixed_hex bytes
     end
 
     # Hashes a string with the Keccak-256 algorithm.

--- a/spec/eth/utils_spec.rb
+++ b/spec/eth/utils_spec.rb
@@ -7,22 +7,20 @@ describe Eth::Utils do
     it "can create ethereum address from random keys" do
       alice = Eth::Utils.public_key_to_address Eth::Key.new.public_bytes
       expect(alice).to be
-      expect(Eth::Utils.is_prefixed? alice).to be_truthy
-      expect(alice.size).to eq 42
+      expect(Eth::Utils.is_prefixed? alice.to_s).to be_truthy
+      expect(alice.checksummed.size).to eq 42
 
       # same as alice but trying to insert hex
       bob = Eth::Utils.public_key_to_address Eth::Key.new.public_hex
       expect(bob).to be
-      expect(Eth::Utils.is_prefixed? bob).to be_truthy
-      expect(bob.size).to eq 42
+      expect(Eth::Utils.is_prefixed? bob.to_s).to be_truthy
+      expect(bob.checksummed.size).to eq 42
     end
 
     it "turns a hex public key into a hex address" do
       address = "0x8ABC566c5198bc6993526DB697FFe58ce4e2425A"
       public_hex = "0463a1ad6824c03f81ad6c9c224384172c67f6bfd2dbde8c4747a033629b531ae3284db3045e4e40c2b865e22a806ae7dff9264299ea8696321f689d6e134d937e"
-      expect(Eth::Utils.public_key_to_address public_hex).to eq address.downcase
-      # @TODO Checksummed addresses
-      # expect(Eth::Utils.public_key_to_address public_hex).to eq address
+      expect(Eth::Utils.public_key_to_address(public_hex).to_s).to eq address
     end
   end
 


### PR DESCRIPTION
removing the TODO

I think it's sensible to not return a string but rather provide access to the Address object.