### PR TITLE
eth/key: allow chain_id empty for signing messages/data

### DIFF
--- a/lib/eth/chain.rb
+++ b/lib/eth/chain.rb
@@ -124,8 +124,13 @@ module Eth
     # @param recovery_id [Integer] signature recovery id.
     # @param chain_id [Integer] the chain id the signature was generated on.
     # @return [Integer] the signature's `v` value.
-    def to_v(recovery_id, chain_id = ETHEREUM)
-      v = 2 * chain_id + 35 + recovery_id
+    def to_v(recovery_id, chain_id = nil)
+      if chain_id.nil? or chain_id < 1
+        v = 27 + recovery_id
+      else
+        v = 2 * chain_id + 35 + recovery_id
+      end
+      return v
     end
 
     # Converst a `v` value into a chain ID. This does not work for legacy signatures

--- a/lib/eth/key.rb
+++ b/lib/eth/key.rb
@@ -68,7 +68,7 @@ module Eth
     # @param blob [String] that arbitrary data to be signed.
     # @param chain_id [Integer] the chain id the signature should be generated on.
     # @return [String] a hexa-decimal signature.
-    def sign(blob, chain_id = Chain::ETHEREUM)
+    def sign(blob, chain_id = nil)
       context = Secp256k1::Context.new
       compact, recovery_id = context.sign_recoverable(@private_key, blob).compact
       signature = compact.bytes
@@ -88,7 +88,7 @@ module Eth
     # @param message [String] the message string to be prefixed and signed.
     # @param chain_id [Integer] the chain id the signature should be generated on.
     # @return [String] an EIP-191 conform, hexa-decimal signature.
-    def personal_sign(message, chain_id = Chain::ETHEREUM)
+    def personal_sign(message, chain_id = nil)
       prefixed_message = Signature.prefix_message message
       hashed_message = Util.keccak256 prefixed_message
       sign hashed_message, chain_id
@@ -101,7 +101,7 @@ module Eth
     # @param typed_data [Array] all the data in the typed data structure to be signed.
     # @param chain_id [Integer] the chain id the signature should be generated on.
     # @return [String] an EIP-712 conform, hexa-decimal signature.
-    def sign_typed_data(typed_data, chain_id = Chain::ETHEREUM)
+    def sign_typed_data(typed_data, chain_id = nil)
       hash_to_sign = Eip712.hash typed_data
       sign hash_to_sign, chain_id
     end

--- a/spec/eth/chain_spec.rb
+++ b/spec/eth/chain_spec.rb
@@ -44,8 +44,10 @@ describe Chain do
 
   describe ".to_v .to_recovery_id .to_chain_id" do
     it "can convert ethereum recovery ids to v" do
-      expect(Chain.to_v 0).to eq 37
-      expect(Chain.to_v 1).to eq 38
+      expect(Chain.to_v 0).to eq 27
+      expect(Chain.to_v 1).to eq 28
+      expect(Chain.to_v 0, Chain::ETHEREUM).to eq 37
+      expect(Chain.to_v 1, Chain::ETHEREUM).to eq 38
     end
 
     it "can convert other chain's recovery ids to v" do

--- a/spec/eth/key_spec.rb
+++ b/spec/eth/key_spec.rb
@@ -147,7 +147,7 @@ describe Key do
 
     it "passes EIP-712 mail example with private key of cow" do
       expect(cow.address.to_s).to eq mail_data[:message][:from][:wallet]
-      expect(cow.sign_typed_data mail_data).to eq "4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b9156226"
+      expect(cow.sign_typed_data mail_data).to eq "4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b915621c"
     end
 
     # The EIP-712 test from MetaMask.
@@ -172,7 +172,7 @@ describe Key do
     subject(:grace) { Key.new priv: "4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0" }
 
     it "passes EIP-712 metamask test data with known private key" do
-      expect(grace.sign_typed_data test_data).to eq "f6cda8eaf5137e8cc15d48d03a002b0512446e2a7acbc576c01cfbe40ad9345663ccda8884520d98dece9a8bfe38102851bdae7f69b3d8612b9808e63378016025"
+      expect(grace.sign_typed_data test_data).to eq "f6cda8eaf5137e8cc15d48d03a002b0512446e2a7acbc576c01cfbe40ad9345663ccda8884520d98dece9a8bfe38102851bdae7f69b3d8612b9808e6337801601b"
     end
   end
 


### PR DESCRIPTION
fix #45 