### PR TITLE
eth/abi/event: batch log decoder

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -2,6 +2,7 @@ The Ruby-Eth Contributors are:
 * Steve Ellis @se3000
 * Afri Schoedon @q9f
 * John Omar @chainoperator
+* Joshua Peek @josh
 
 See also:
 * https://github.com/q9f/eth.rb/graphs/contributors

--- a/lib/eth/abi.rb
+++ b/lib/eth/abi.rb
@@ -291,6 +291,17 @@ module Eth
       end
     end
 
+    # Build event signature string from ABI interface.
+    #
+    # @param interface [Hash] ABI event interface.
+    # @return [String] interface signature string.
+    def signature(interface)
+      name = interface.fetch("name")
+      inputs = interface.fetch("inputs", [])
+      types = inputs.map { |i| i.fetch("type") }
+      "#{name}(#{types.join(",")})"
+    end
+
     private
 
     # Properly encodes unsigned integers.

--- a/lib/eth/abi/event.rb
+++ b/lib/eth/abi/event.rb
@@ -24,6 +24,15 @@ module Eth
     module Event
       extend self
 
+      # Compute topic for ABI event interface.
+      #
+      # @param interface [Hash] ABI event interface.
+      # @return [String] a hex-string topic.
+      def compute_topic(interface)
+        sig = Abi.signature(interface)
+        Util.prefix_hex(Util.bin_to_hex(Util.keccak256(sig)))
+      end
+
       # Decodes event log argument values.
       #
       # @param inputs [Array] event ABI types.

--- a/lib/eth/abi/event.rb
+++ b/lib/eth/abi/event.rb
@@ -29,15 +29,22 @@ module Eth
       # @param inputs [Array] event ABI types.
       # @param data [String] ABI event data to be decoded.
       # @param topics [Array] ABI event topics to be decoded.
+      # @param anonymous [Boolean] If event signature is excluded from topics.
       # @return [[Array, Hash]] decoded positional arguments and decoded keyword arguments.
       # @raise [DecodingError] if decoding fails for type.
-      def decode_log(inputs, data, topics)
+      def decode_log(inputs, data, topics, anonymous = false)
         topic_inputs, data_inputs = inputs.partition { |i| i["indexed"] }
 
         topic_types = topic_inputs.map { |i| i["type"] }
         data_types = data_inputs.map { |i| i["type"] }
 
-        decoded_topics = topics[1..-1].map.with_index { |t, i| Abi.decode([topic_types[i]], t)[0] }
+        # If event is anonymous, all topics are arguments. Otherwise, the first
+        # topic will be the event signature.
+        if anonymous == false
+          topics = topics[1..-1]
+        end
+
+        decoded_topics = topics.map.with_index { |t, i| Abi.decode([topic_types[i]], t)[0] }
         decoded_data = Abi.decode(data_types, data)
 
         args = []

--- a/spec/eth/abi/event_spec.rb
+++ b/spec/eth/abi/event_spec.rb
@@ -118,4 +118,33 @@ describe Abi::Event do
       expect(kwargs[:values]).to eq [1, 1]
     end
   end
+
+  it "can decode anonymous Transfer event" do
+    interface = {
+      "type" => "event",
+      "name" => "Transfer",
+      "anonymous" => true,
+      "inputs" => [
+        { "indexed" => true, "internalType" => "address", "name" => "from", "type" => "address" },
+        { "indexed" => true, "internalType" => "address", "name" => "to", "type" => "address" },
+        { "indexed" => false, "internalType" => "uint256", "name" => "value", "type" => "uint256" },
+      ],
+    }
+
+    data = "0x00000000000000000000000000000000000000000000000000000002540be400"
+    topics = [
+      "0x00000000000000000000000071660c4005ba85c37ccec55d0c4493e66fe775d3",
+      "0x000000000000000000000000639671019ddd8ec28d35113d8d1c5f1bbfd7e0be",
+    ]
+
+    args, kwargs = Eth::Abi::Event.decode_log(interface["inputs"], data, topics, true)
+
+    expect(args[0]).to eq "0x71660c4005ba85c37ccec55d0c4493e66fe775d3"
+    expect(args[1]).to eq "0x639671019ddd8ec28d35113d8d1c5f1bbfd7e0be"
+    expect(args[2]).to eq 10000000000
+
+    expect(kwargs[:from]).to eq "0x71660c4005ba85c37ccec55d0c4493e66fe775d3"
+    expect(kwargs[:to]).to eq "0x639671019ddd8ec28d35113d8d1c5f1bbfd7e0be"
+    expect(kwargs[:value]).to eq 10000000000
+  end
 end

--- a/spec/eth/abi/event_spec.rb
+++ b/spec/eth/abi/event_spec.rb
@@ -166,4 +166,59 @@ describe Abi::Event do
     expect(kwargs[:to]).to eq "0x639671019ddd8ec28d35113d8d1c5f1bbfd7e0be"
     expect(kwargs[:value]).to eq 10000000000
   end
+
+  describe ".decode_logs" do
+    it "can decode ERC-20 Transfer event" do
+      logs = [
+        {
+          "address" => "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          "blockHash" => "0x41bbb59a6ae30e1e62379d100b0bc3485384843c51bad2c2f7a7a9b86848f19e",
+          "blockNumber" => "0xddcb4d",
+          "data" => "0x00000000000000000000000000000000000000000000000000000002540be400",
+          "logIndex" => "0xcd",
+          "removed" => false,
+          "topics" => [
+            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+            "0x00000000000000000000000071660c4005ba85c37ccec55d0c4493e66fe775d3",
+            "0x000000000000000000000000639671019ddd8ec28d35113d8d1c5f1bbfd7e0be",
+          ],
+          "transactionHash" => "0xcff6d58021eb9f743e29ca84cb94964332cc91babcc3533714d34264535ed3c5",
+          "transactionIndex" => "0x8c",
+        },
+        {
+          "address" => "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          "blockHash" => "0x7461cf774021f421441df69bb1a04c66fac58fb72071c8286b2874d2e41ba448",
+          "blockNumber" => "0xdcc880",
+          "data" => "0x00000000000000000000000000000000000000000000000000000000aa3752a2",
+          "logIndex" => "0xbc",
+          "removed" => false,
+          "topics" => [
+            "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925",
+            "0x0000000000000000000000007f8c1877ed0da352f78be4fe4cda58bb804a30df",
+            "0x00000000000000000000000068b3465833fb72a70ecdf485e0e4c7bd8665fc45",
+          ],
+          "transactionHash" => "0xcbf51c188fb3d24760d083c6b53a4b604d2658321ef92cd48489ce3804b3de2b",
+          "transactionIndex" => "0x78",
+        },
+      ]
+
+      results = Eth::Abi::Event.decode_logs(erc20_abi, logs).to_a
+
+      expect(results[0][:log]).to eq logs[0]
+      expect(results[0][:name]).to eq "Transfer"
+      expect(results[0][:signature]).to eq "Transfer(address,address,uint256)"
+      expect(results[0][:topic]).to eq "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+      expect(results[0][:kwargs][:from]).to eq "0x71660c4005ba85c37ccec55d0c4493e66fe775d3"
+      expect(results[0][:kwargs][:to]).to eq "0x639671019ddd8ec28d35113d8d1c5f1bbfd7e0be"
+      expect(results[0][:kwargs][:value]).to eq 10000000000
+
+      expect(results[1][:log]).to eq logs[1]
+      expect(results[1][:name]).to eq "Approval"
+      expect(results[1][:signature]).to eq "Approval(address,address,uint256)"
+      expect(results[1][:topic]).to eq "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+      expect(results[1][:kwargs][:owner]).to eq "0x7f8c1877ed0da352f78be4fe4cda58bb804a30df"
+      expect(results[1][:kwargs][:spender]).to eq "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45"
+      expect(results[1][:kwargs][:value]).to eq 2855752354
+    end
+  end
 end

--- a/spec/eth/abi/event_spec.rb
+++ b/spec/eth/abi/event_spec.rb
@@ -6,8 +6,27 @@ describe Abi::Event do
   let(:erc20_abi_file) { File.read "spec/fixtures/abi/ERC20.json" }
   subject(:erc20_abi) { JSON.parse erc20_abi_file }
 
+  let(:erc721_abi_file) { File.read "spec/fixtures/abi/ERC721.json" }
+  subject(:erc721_abi) { JSON.parse erc721_abi_file }
+
   let(:erc1155_abi_file) { File.read "spec/fixtures/abi/ERC1155.json" }
   subject(:erc1155_abi) { JSON.parse erc1155_abi_file }
+
+  describe ".compute_topic" do
+    it "computes topic hash for event interfaces" do
+      interface = erc20_abi.find { |i| i["type"] == "event" && i["name"] == "Transfer" }
+      expect(Abi::Event.compute_topic(interface)).to eq "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+      interface = erc20_abi.find { |i| i["type"] == "event" && i["name"] == "Approval" }
+      expect(Abi::Event.compute_topic(interface)).to eq "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+
+      interface = erc721_abi.find { |i| i["type"] == "event" && i["name"] == "Transfer" }
+      expect(Abi::Event.compute_topic(interface)).to eq "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+      interface = erc1155_abi.find { |i| i["type"] == "event" && i["name"] == "TransferSingle" }
+      expect(Abi::Event.compute_topic(interface)).to eq "0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62"
+    end
+  end
 
   describe ".decode_log" do
     it "can decode ERC-20 Transfer event" do

--- a/spec/eth/abi/event_spec.rb
+++ b/spec/eth/abi/event_spec.rb
@@ -200,6 +200,15 @@ describe Abi::Event do
           "transactionHash" => "0xcbf51c188fb3d24760d083c6b53a4b604d2658321ef92cd48489ce3804b3de2b",
           "transactionIndex" => "0x78",
         },
+        {
+          "address" => "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          "data" => "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "topics" => [
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+          ],
+        },
       ]
 
       results = Eth::Abi::Event.decode_logs(erc20_abi, logs).to_a
@@ -221,6 +230,10 @@ describe Abi::Event do
       expect(decoded_log.kwargs[:owner]).to eq "0x7f8c1877ed0da352f78be4fe4cda58bb804a30df"
       expect(decoded_log.kwargs[:spender]).to eq "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45"
       expect(decoded_log.kwargs[:value]).to eq 2855752354
+
+      log, decoded_log = results[2]
+      expect(log).to eq logs[2]
+      expect(decoded_log).to eq nil
     end
   end
 end

--- a/spec/eth/abi/event_spec.rb
+++ b/spec/eth/abi/event_spec.rb
@@ -204,21 +204,23 @@ describe Abi::Event do
 
       results = Eth::Abi::Event.decode_logs(erc20_abi, logs).to_a
 
-      expect(results[0][:log]).to eq logs[0]
-      expect(results[0][:name]).to eq "Transfer"
-      expect(results[0][:signature]).to eq "Transfer(address,address,uint256)"
-      expect(results[0][:topic]).to eq "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
-      expect(results[0][:kwargs][:from]).to eq "0x71660c4005ba85c37ccec55d0c4493e66fe775d3"
-      expect(results[0][:kwargs][:to]).to eq "0x639671019ddd8ec28d35113d8d1c5f1bbfd7e0be"
-      expect(results[0][:kwargs][:value]).to eq 10000000000
+      log, decoded_log = results[0]
+      expect(log).to eq logs[0]
+      expect(decoded_log.name).to eq "Transfer"
+      expect(decoded_log.signature).to eq "Transfer(address,address,uint256)"
+      expect(decoded_log.topic).to eq "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+      expect(decoded_log.kwargs[:from]).to eq "0x71660c4005ba85c37ccec55d0c4493e66fe775d3"
+      expect(decoded_log.kwargs[:to]).to eq "0x639671019ddd8ec28d35113d8d1c5f1bbfd7e0be"
+      expect(decoded_log.kwargs[:value]).to eq 10000000000
 
-      expect(results[1][:log]).to eq logs[1]
-      expect(results[1][:name]).to eq "Approval"
-      expect(results[1][:signature]).to eq "Approval(address,address,uint256)"
-      expect(results[1][:topic]).to eq "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
-      expect(results[1][:kwargs][:owner]).to eq "0x7f8c1877ed0da352f78be4fe4cda58bb804a30df"
-      expect(results[1][:kwargs][:spender]).to eq "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45"
-      expect(results[1][:kwargs][:value]).to eq 2855752354
+      log, decoded_log = results[1]
+      expect(log).to eq logs[1]
+      expect(decoded_log.name).to eq "Approval"
+      expect(decoded_log.signature).to eq "Approval(address,address,uint256)"
+      expect(decoded_log.topic).to eq "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+      expect(decoded_log.kwargs[:owner]).to eq "0x7f8c1877ed0da352f78be4fe4cda58bb804a30df"
+      expect(decoded_log.kwargs[:spender]).to eq "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45"
+      expect(decoded_log.kwargs[:value]).to eq 2855752354
     end
   end
 end

--- a/spec/eth/abi_spec.rb
+++ b/spec/eth/abi_spec.rb
@@ -320,4 +320,21 @@ describe Abi do
       expect { Abi.decode_primitive_type(Abi::Type.new("foo", 32, []), "bar") }.to raise_error Abi::DecodingError
     end
   end
+
+  let(:erc20_abi_file) { File.read "spec/fixtures/abi/ERC20.json" }
+  subject(:erc20_abi) { JSON.parse erc20_abi_file }
+
+  describe ".signature" do
+    it "generates Transfer event signature" do
+      abi = erc20_abi.find { |i| i["type"] == "event" && i["name"] == "Transfer" }
+      signature = Eth::Abi.signature(abi)
+      expect(signature).to eq "Transfer(address,address,uint256)"
+    end
+
+    it "generates transfer function signature" do
+      abi = erc20_abi.find { |i| i["type"] == "function" && i["name"] == "transfer" }
+      signature = Eth::Abi.signature(abi)
+      expect(signature).to eq "transfer(address,uint256)"
+    end
+  end
 end


### PR DESCRIPTION
This adds some additional higher level functionality to the existing low level log decoder I previously.

Now you can do something like this to process log data from a client.

```ruby
logs = infura.eth_get_transaction_receipt(tx_hash)["result"]["logs"]

Eth::Abi::Event.decode_logs(ERC20_ABI, logs).each do |raw_log, log|
  if log && log.name == "Transfer"
    puts log.kwargs[:from], "=>", log.kwargs[:to]
  end
end
```

Maybe this example is worth adding to the README?