### PR TITLE
Add dependency support for openssl 2.2 and greater, including 3.x (#87)

### DIFF
--- a/eth.gemspec
+++ b/eth.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rbsecp256k1", "~> 5.1"
 
   # openssl for encrypted key derivation
-  spec.add_dependency "openssl", "~> 2.2"
+  spec.add_dependency "openssl", ">= 2.2", "< 4.0"
 
   # scrypt for encrypted key derivation
   spec.add_dependency "scrypt", "~> 3.0"


### PR DESCRIPTION
fixes #87 

Eth.rb works with both 2.x and 3.x, gemspec needs a slight adjustment to allow for OpenSSL 2.2 and greater to be supported.

I've limited to anything less then OpenSSL 4.0 incase this included any breaking changes for the major update in the future.