### PR TITLE
Add missing def_delegator for constructor_inputs

### DIFF
--- a/lib/eth/contract.rb
+++ b/lib/eth/contract.rb
@@ -109,6 +109,7 @@ module Eth
         def_delegators :parent, :events
         def_delegators :parent, :address, :address=
         def_delegator :parent, :functions
+        def_delegator :parent, :constructor_inputs
         define_method :parent do
           parent
         end


### PR DESCRIPTION
 `constructor_inputs` when creating a contract `from_file` was missing.

We should probably enable passing constructor params with something like this:

```
    def encode_constructor_params(contract, args)
      types = contract.constructor_inputs.map { |input| input.type }
      Util.bin_to_hex(Eth::Abi.encode(types, args))
    end
```

as well, and appending it to `data` in `deploy` and `transact`.

Be happy to extend this PR if that's a direction we'd want to go.