### PR TITLE
eth/abi: fix handling of hex values for byte strings

### DIFF
--- a/lib/eth/abi.rb
+++ b/lib/eth/abi.rb
@@ -346,6 +346,12 @@ module Eth
     # Properly encodes byte-strings.
     def encode_bytes(arg, type)
       raise EncodingError, "Expecting String: #{arg}" unless arg.instance_of? String
+
+      if Util.is_prefixed? arg
+        arg = Util.remove_hex_prefix arg
+        arg = Util.hex_to_bin arg
+      end
+
       if type.sub_type.empty?
         size = Util.zpad_int arg.size
         padding = Constant::BYTE_ZERO * (Util.ceil32(arg.size) - arg.size)

--- a/spec/eth/abi_spec.rb
+++ b/spec/eth/abi_spec.rb
@@ -203,6 +203,10 @@ describe Abi do
       expect(Abi.encode_type t_address, "0x" + "ff" * 20).to eq Util.zpad("\xff" * 20, 32)
     end
 
+    it "can handle hex-strings for bytes types" do
+      expect(Abi.encode ["bytes4"], ["0x80ac58cd"]).to eq "\x80\xACX\xCD#{"\x00" * 28}"
+    end
+
     it "can decode types" do
 
       # https://github.com/cryptape/ruby-ethereum-abi/blob/90d4fa3fc6b568581165eaacdc506b9b9b49e520/test/abi_test.rb#L105


### PR DESCRIPTION
closes #98 

however, if a hexstring is not prefixed, it will be hard to determine whether it is a bytes string or not. we'll potentially see this popping up again.