### PR TITLE
Fix Eth::Abi::DecodingError in call method

### DIFF
--- a/lib/eth/client.rb
+++ b/lib/eth/client.rb
@@ -241,7 +241,7 @@ module Eth
       func = contract.functions.select { |func| func.name == function_name }[0]
       raise ArgumentError, "function_name does not exist!" if func.nil?
       output = call_raw(contract, func, *args, **kwargs)
-      if output.length == 1
+      if output&.length == 1
         return output[0]
       else
         return output
@@ -422,6 +422,7 @@ module Eth
       end
       raw_result = eth_call(params)["result"]
       types = func.outputs.map { |i| i.type }
+      return nil if raw_result == "0x"
       Eth::Abi.decode(types, raw_result)
     end
 

--- a/spec/eth/client_spec.rb
+++ b/spec/eth/client_spec.rb
@@ -118,7 +118,7 @@ describe Client do
     end
 
     it "return nil if raw result is 0x" do
-      expect(geth_dev_http.call(erc20_contract, "balanceOf", address: address)).to be_nil
+      expect(geth_dev_http.call(erc20_contract, "balanceOf", address)).to be_nil
     end
 
     it "called function name not defined" do

--- a/spec/eth/client_spec.rb
+++ b/spec/eth/client_spec.rb
@@ -106,11 +106,19 @@ describe Client do
     subject(:test_key) { Key.new }
     subject(:contract) { Eth::Contract.from_file(file: "spec/fixtures/contracts/dummy.sol") }
     subject(:test_contract) { Eth::Contract.from_file(file: "spec/fixtures/contracts/simple_registry.sol") }
+    let(:erc20_abi_file) { File.read "spec/fixtures/abi/ERC20.json" }
+    let(:address) { Eth::Address.new("0xd496b23d61f88a8c7758fca7560dcfac7b3b01f9").address }
+    subject(:erc20_abi) { JSON.parse erc20_abi_file }
+    subject(:erc20_contract) { Eth::Contract.from_abi(abi: erc20_abi, name: "ERC20", address: address) }
 
     it "call function name" do
       geth_dev_http.deploy_and_wait(contract)
       result = geth_dev_http.call(contract, "get")
       expect(result).to eq(0)
+    end
+
+    it "return nil if raw result is 0x" do
+      expect(geth_dev_http.call(erc20_contract, "balanceOf", address: address)).to be_nil
     end
 
     it "called function name not defined" do


### PR DESCRIPTION
resolves https://github.com/q9f/eth.rb/issues/104
If raw result in call() is 0x, nil is returned.