### PR TITLE
Include contract constructor args when estimating intrinsic gas

### DIFF
--- a/lib/eth/client.rb
+++ b/lib/eth/client.rb
@@ -181,11 +181,11 @@ module Eth
     def deploy(contract, *args, **kwargs)
       raise ArgumentError, "Cannot deploy contract without source or binary!" if contract.bin.nil?
       raise ArgumentError, "Missing contract constructor params!" if contract.constructor_inputs.length != args.length
-      gas_limit = Tx.estimate_intrinsic_gas(contract.bin) + Tx::CREATE_GAS
       data = contract.bin
       unless args.empty?
         data += encode_constructor_params(contract, args)
       end
+      gas_limit = Tx.estimate_intrinsic_gas(data) + Tx::CREATE_GAS
       params = {
         value: 0,
         gas_limit: gas_limit,


### PR DESCRIPTION
I was receiving "intrinsic gas too low errors" while trying to deploy contracts with several constructor arguments. Upon inspection, I noticed that constructor argument data was not included in the intrinsic gas calculation. Including constructor data when computing the fee fixed the problem for me.