### PR TITLE
eth/abi: raise error if numeric comes as string

### DIFF
--- a/lib/eth/abi.rb
+++ b/lib/eth/abi.rb
@@ -306,6 +306,7 @@ module Eth
 
     # Properly encodes unsigned integers.
     def encode_uint(arg, type)
+      raise ArgumentError, "Don't know how to handle this input." unless arg.is_a? Numeric
       raise ValueOutOfBounds, "Number out of range: #{arg}" if arg > Constant::UINT_MAX or arg < Constant::UINT_MIN
       real_size = type.sub_type.to_i
       i = arg.to_i
@@ -315,6 +316,7 @@ module Eth
 
     # Properly encodes signed integers.
     def encode_int(arg, type)
+      raise ArgumentError, "Don't know how to handle this input." unless arg.is_a? Numeric
       raise ValueOutOfBounds, "Number out of range: #{arg}" if arg > Constant::INT_MAX or arg < Constant::INT_MIN
       real_size = type.sub_type.to_i
       i = arg.to_i
@@ -330,6 +332,7 @@ module Eth
 
     # Properly encodes unsigned fixed-point numbers.
     def encode_ufixed(arg, type)
+      raise ArgumentError, "Don't know how to handle this input." unless arg.is_a? Numeric
       high, low = type.sub_type.split("x").map(&:to_i)
       raise ValueOutOfBounds, arg unless arg >= 0 and arg < 2 ** high
       return Util.zpad_int((arg * 2 ** low).to_i)
@@ -337,6 +340,7 @@ module Eth
 
     # Properly encodes signed fixed-point numbers.
     def encode_fixed(arg, type)
+      raise ArgumentError, "Don't know how to handle this input." unless arg.is_a? Numeric
       high, low = type.sub_type.split("x").map(&:to_i)
       raise ValueOutOfBounds, arg unless arg >= -2 ** (high - 1) and arg < 2 ** (high - 1)
       i = (arg * 2 ** low).to_i

--- a/lib/eth/abi.rb
+++ b/lib/eth/abi.rb
@@ -306,7 +306,6 @@ module Eth
 
     # Properly encodes unsigned integers.
     def encode_uint(arg, type)
-      arg = arg.to_i if arg.is_a? String
       raise ValueOutOfBounds, "Number out of range: #{arg}" if arg > Constant::UINT_MAX or arg < Constant::UINT_MIN
       real_size = type.sub_type.to_i
       i = arg.to_i
@@ -316,7 +315,6 @@ module Eth
 
     # Properly encodes signed integers.
     def encode_int(arg, type)
-      arg = arg.to_i if arg.is_a? String
       raise ValueOutOfBounds, "Number out of range: #{arg}" if arg > Constant::INT_MAX or arg < Constant::INT_MIN
       real_size = type.sub_type.to_i
       i = arg.to_i

--- a/spec/eth/abi_spec.rb
+++ b/spec/eth/abi_spec.rb
@@ -61,13 +61,6 @@ describe Abi do
       end
     end
 
-    it "can encode numbers from string inputs" do
-      expect(Abi.encode(["uint256"], ["10000000000000000000000"])).to eq Abi.encode(["uint256"], [10000000000000000000000])
-      expect(Abi.decode(["uint256"], "00000000000000000000000000000000000000000000021e19e0c9bab2400000")).to eq [10000000000000000000000]
-      expect(Abi.encode(["int256"], ["20000000000000000000000"])).to eq Abi.encode(["int256"], [20000000000000000000000])
-      expect(Abi.decode(["int256"], "00000000000000000000000000000000000000000000043c33c1937564800000")).to eq [20000000000000000000000]
-    end
-
     it "can do encode and decode complex types" do
       types = [
         "bool",


### PR DESCRIPTION
There is no way to tell whether a string is a decimal, octal, hexadecimal, etc. 

Reverts q9f/eth.rb#112