### PR TITLE
eth/signature: fix prefix_message for multibyte characters

### DIFF
--- a/lib/eth/signature.rb
+++ b/lib/eth/signature.rb
@@ -38,7 +38,7 @@ module Eth
     # @param message [String] the message string to be prefixed.
     # @return [String] an EIP-191 prefixed string.
     def prefix_message(message)
-      "#{EIP191_PREFIX_BYTE}Ethereum Signed Message:\n#{message.size}#{message}"
+      "#{EIP191_PREFIX_BYTE}Ethereum Signed Message:\n#{message.bytesize}#{message}"
     end
 
     # Dissects a signature blob of 65+ bytes into its `r`, `s`, and `v`

--- a/spec/eth/signature_spec.rb
+++ b/spec/eth/signature_spec.rb
@@ -8,6 +8,11 @@ describe Signature do
       proof = "This is proof that I, user A, have access to this address."
       expect(Signature.prefix_message proof).to eq "\x19Ethereum Signed Message:\n58This is proof that I, user A, have access to this address."
     end
+
+    it "can properly prefix messages with multibyte characters" do
+      hello = "Hello World!🌏"
+      expect(Signature.prefix_message hello).to eq "\x19Ethereum Signed Message:\n16Hello World!🌏"
+    end
   end
 
   describe ".dissect" do


### PR DESCRIPTION

Hi, thanks for the useful gem!

I encountered a problem when verifying signature signed with [web3.js](https://web3js.readthedocs.io/) that in some cases could not be verified correctly.
So I tried signing messages using web3.js and eth.rb, and noticed that different signatures are generated only if they contain multibyte characters.

Here is an example.

| message | signature (generated by web3.js) | signature (generated by eth.rb) |
| :-- | :-- | :-- |
| hello, ethereum! | 0x7b84abfdddd62aee9c598b98f74ae17b7b497b5530a92bd8f262ac33bccaed230fce76c74609e1c8c96b1bebe1a62e46477d3327481d8ed674d6c51bb98c689c1b | 0x7b84abfdddd62aee9c598b98f74ae17b7b497b5530a92bd8f262ac33bccaed230fce76c74609e1c8c96b1bebe1a62e46477d3327481d8ed674d6c51bb98c689c1b |
| こんにちは、イーサリアム! | 0xdd809dedbf2099c2306bb443ae201e24fc7fd7fd4f0c00a961b5bae0decc74d715b4715cab5010157e6662b8abcad0062eb47b63cce986623d43a884eb9ff2e41c | 0xf502a9db634e0b1e5ccbb88ffe934855c5211b072bcf4b5b51084086c804c61b35b8e29780071685673d8bd3fe2df1f9ee5b569ba13f9363afc2833b0f66215a1b |

### What's happening?

I found a difference in the logic of prefixing with "known messages" in web3.js and eth.rb.
In the known message, eth.rb counts the number of **characters**, but web3.js [counts the number of **bytes**](https://github.com/ChainSafe/web3.js/blob/739217cfccfaf835d64d3a122341b614250f7356/packages/web3-eth-accounts/src/index.js#L454-L462).

### Which is correct?

The [EIP-191](https://eips.ethereum.org/EIPS/eip-191) specification quotes go-ethereum as follows.

```go
"\x19Ethereum Signed Message:\n" + len(message).
```

`len`, a built-in function of golang, is designed to "returns the number of bytes" in the case of string.
ref: https://pkg.go.dev/builtin@go1.18.3#len

Therefore, I decided that it was a mistake on the eth.rb side and created this PR.
