### PR TITLE
Add gas limit override option for contract deployments

### DIFF
--- a/lib/eth/client.rb
+++ b/lib/eth/client.rb
@@ -159,6 +159,7 @@ module Eth
     #   *args Optional variable constructor parameter list
     #   **sender_key [Eth::Key] the sender private key.
     #   **legacy [Boolean] enables legacy transactions (pre-EIP-1559).
+    #   **gas_limit [Integer] optional gas limit override for deploying the contract.
     # @return [String] the contract address.
     def deploy_and_wait(contract, *args, **kwargs)
       hash = wait_for_tx(deploy(contract, *args, **kwargs))
@@ -176,6 +177,7 @@ module Eth
     #   *args Optional variable constructor parameter list
     #   **sender_key [Eth::Key] the sender private key.
     #   **legacy [Boolean] enables legacy transactions (pre-EIP-1559).
+    #   **gas_limit [Integer] optional gas limit override for deploying the contract.
     # @return [String] the transaction hash.
     # @raise [ArgumentError] in case the contract does not have any source.
     def deploy(contract, *args, **kwargs)
@@ -185,7 +187,11 @@ module Eth
       unless args.empty?
         data += encode_constructor_params(contract, args)
       end
-      gas_limit = Tx.estimate_intrinsic_gas(data) + Tx::CREATE_GAS
+      gas_limit = if kwargs[:gas_limit]
+        kwargs[:gas_limit]
+      else
+        Tx.estimate_intrinsic_gas(data) + Tx::CREATE_GAS
+      end
       params = {
         value: 0,
         gas_limit: gas_limit,

--- a/lib/eth/client.rb
+++ b/lib/eth/client.rb
@@ -188,10 +188,10 @@ module Eth
         data += encode_constructor_params(contract, args)
       end
       gas_limit = if kwargs[:gas_limit]
-        kwargs[:gas_limit]
-      else
-        Tx.estimate_intrinsic_gas(data) + Tx::CREATE_GAS
-      end
+          kwargs[:gas_limit]
+        else
+          Tx.estimate_intrinsic_gas(data) + Tx::CREATE_GAS
+        end
       params = {
         value: 0,
         gas_limit: gas_limit,

--- a/lib/eth/client.rb
+++ b/lib/eth/client.rb
@@ -237,12 +237,13 @@ module Eth
     #   @param contract [Eth::Contract] subject contract to call.
     #   @param function_name [String] method name to be called.
     #   @param value [Integer|String] function arguments.
-    # @overload call(contract, function_name, value, sender_key, legacy)
+    # @overload call(contract, function_name, value, sender_key, legacy, gas_limit)
     #   @param contract [Eth::Contract] subject contract to call.
     #   @param function_name [String] method name to be called.
     #   @param value [Integer|String] function arguments.
     #   @param sender_key [Eth::Key] the sender private key.
     #   @param legacy [Boolean] enables legacy transactions (pre-EIP-1559).
+    #   @param gas_limit [Integer] optional gas limit override for deploying the contract.
     # @return [Object] returns the result of the call.
     def call(contract, function_name, *args, **kwargs)
       func = contract.functions.select { |func| func.name == function_name }[0]
@@ -265,16 +266,21 @@ module Eth
     #   @param contract [Eth::Contract] subject contract to call.
     #   @param function_name [String] method name to be called.
     #   @param value [Integer|String] function arguments.
-    # @overload transact(contract, function_name, value, sender_key, legacy, address)
+    # @overload transact(contract, function_name, value, sender_key, legacy, address, gas_limit)
     #   @param contract [Eth::Contract] subject contract to call.
     #   @param function_name [String] method name to be called.
     #   @param value [Integer|String] function arguments.
     #   @param sender_key [Eth::Key] the sender private key.
     #   @param legacy [Boolean] enables legacy transactions (pre-EIP-1559).
     #   @param address [String] contract address.
+    #   @param gas_limit [Integer] optional gas limit override for deploying the contract.
     # @return [Object] returns the result of the call.
     def transact(contract, function_name, *args, **kwargs)
-      gas_limit = Tx.estimate_intrinsic_gas(contract.bin) + Tx::CREATE_GAS
+      gas_limit = if kwargs[:gas_limit]
+          kwargs[:gas_limit]
+        else
+          Tx.estimate_intrinsic_gas(contract.bin) + Tx::CREATE_GAS
+        end
       fun = contract.functions.select { |func| func.name == function_name }[0]
       params = {
         value: 0,
@@ -399,7 +405,11 @@ module Eth
 
     # Non-transactional function call called from call().
     def call_raw(contract, func, *args, **kwargs)
-      gas_limit = Tx.estimate_intrinsic_gas(contract.bin) + Tx::CREATE_GAS
+      gas_limit = if kwargs[:gas_limit]
+          kwargs[:gas_limit]
+        else
+          Tx.estimate_intrinsic_gas(contract.bin) + Tx::CREATE_GAS
+        end
       params = {
         gas_limit: gas_limit,
         chain_id: chain_id,

--- a/spec/eth/client_spec.rb
+++ b/spec/eth/client_spec.rb
@@ -93,6 +93,11 @@ describe Client do
       expect(address).to start_with "0x"
     end
 
+    it "deploys the contract with a gas limit override" do
+      address = geth_dev_http.deploy_and_wait(contract, gas_limit: 1_000_000)
+      expect(address).to start_with "0x"
+    end
+
     it "deploy the contract with constructor params" do
       contract = Contract.from_file(file: "spec/fixtures/contracts/greeter.sol", contract_index: 0)
       address = geth_dev_http.deploy_and_wait(contract, "Hello!")
@@ -123,6 +128,12 @@ describe Client do
       expect(result).to eq(0)
     end
 
+    it "calls a function with gas_limit override" do
+      geth_dev_http.deploy_and_wait(contract)
+      result = geth_dev_http.call(contract, "get", gas_limit: 60_000)
+      expect(result).to eq(0)
+    end
+
     it "return nil if raw result is 0x" do
       expect(geth_dev_http.call(erc20_contract, "balanceOf", address)).to be_nil
     end
@@ -148,6 +159,14 @@ describe Client do
       response = geth_dev_http.call(test_contract, "get")
       expect(response).to eq([0, 0])
       geth_dev_http.transact_and_wait(test_contract, "set", 12, 24, address: address)
+      response = geth_dev_http.call(test_contract, "get")
+      expect(response).to eq([12, 24])
+    end
+
+    it "transacts with gas limit override" do
+      address = geth_dev_http.deploy_and_wait(test_contract)
+      txn_hash = geth_dev_http.transact_and_wait(test_contract, "set", 12, 24, address: address, gas_limit: 100_000_000)
+      response = geth_dev_http.eth_get_transaction_by_hash(txn_hash)
       response = geth_dev_http.call(test_contract, "get")
       expect(response).to eq([12, 24])
     end


### PR DESCRIPTION
I've had some deployment failures due to running out of gas on deployment **when a constructor is invoked**. In some cases the intrinsic gas limit is off by a factor of 10. This change allows the developer to override the calculated model if necessary, without breaking the API. 