### PR TITLE
Fix Eth:Tx.decode for transaction with s length < 64 chars

### DIFF
--- a/lib/eth/tx/eip1559.rb
+++ b/lib/eth/tx/eip1559.rb
@@ -188,7 +188,7 @@ module Eth
 
         # recover sender address
         v = Chain.to_v recovery_id, chain_id
-        public_key = Signature.recover(unsigned_hash, "#{r}#{s}#{v.to_s(16)}", chain_id)
+        public_key = Signature.recover(unsigned_hash, "#{r.rjust(64, "0")}#{s.rjust(64, "0")}#{v.to_s(16)}", chain_id)
         address = Util.public_key_to_address(public_key).to_s
         @sender = Tx.sanitize_address address
       end

--- a/lib/eth/tx/eip2930.rb
+++ b/lib/eth/tx/eip2930.rb
@@ -183,7 +183,7 @@ module Eth
 
         # recover sender address
         v = Chain.to_v recovery_id, chain_id
-        public_key = Signature.recover(unsigned_hash, "#{r}#{s}#{v.to_s(16)}", chain_id)
+        public_key = Signature.recover(unsigned_hash, "#{r.rjust(64, "0")}#{s.rjust(64, "0")}#{v.to_s(16)}", chain_id)
         address = Util.public_key_to_address(public_key).to_s
         @sender = Tx.sanitize_address address
       end

--- a/lib/eth/tx/legacy.rb
+++ b/lib/eth/tx/legacy.rb
@@ -156,7 +156,7 @@ module Eth
         unless chain_id.nil?
 
           # recover sender address
-          public_key = Signature.recover(unsigned_hash, "#{r.rjust(64, '0')}#{s.rjust(64, '0')}#{v}", chain_id)
+          public_key = Signature.recover(unsigned_hash, "#{r.rjust(64, "0")}#{s.rjust(64, "0")}#{v}", chain_id)
           address = Util.public_key_to_address(public_key).to_s
           @sender = Tx.sanitize_address address
         else

--- a/lib/eth/tx/legacy.rb
+++ b/lib/eth/tx/legacy.rb
@@ -156,7 +156,7 @@ module Eth
         unless chain_id.nil?
 
           # recover sender address
-          public_key = Signature.recover(unsigned_hash, "#{r}#{s}#{v}", chain_id)
+          public_key = Signature.recover(unsigned_hash, "#{r.rjust(64, '0')}#{s.rjust(64, '0')}#{v}", chain_id)
           address = Util.public_key_to_address(public_key).to_s
           @sender = Tx.sanitize_address address
         else

--- a/spec/eth/tx_spec.rb
+++ b/spec/eth/tx_spec.rb
@@ -101,4 +101,19 @@ describe Tx do
       expect(tx.chain_id).to eq 4901
     end
   end
+
+  describe ".decode transaction with small s" do
+    it "transaction with s with length 62" do
+
+      raw = "0xf86b820e8485012a05f200831e848094ffe811714ab35360b67ee195ace7c10d93f89d8c80844e71d92d8194a07b8f34a8fb85d850b3be4fc0330382e125e4216df5598c6d2c3bc47954684cf99f35ef53ee007c2f705eca91448b5c86e81d10f659ad868409bac8197bba9814"
+      tx = Tx.decode raw
+      expect(tx.sender).to eq Util.remove_hex_prefix Address.new("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266").to_s
+      expect(tx.destination).to eq Util.remove_hex_prefix "0xffe811714ab35360b67ee195ace7c10d93f89d8c"
+      expect(tx.amount).to eq 0
+      expect(tx.hash).to eq Util.remove_hex_prefix "0x061bff624de0bdd20f557c02b6fbab92ca436871ff31f69ffdd6dc830a8e9709"
+      expect(tx.signature_v).to eq "94"
+      expect(tx.chain_id).to eq 56
+    end
+  end
+
 end

--- a/spec/eth/tx_spec.rb
+++ b/spec/eth/tx_spec.rb
@@ -104,7 +104,6 @@ describe Tx do
 
   describe ".decode transaction with small s" do
     it "transaction with s with length 62" do
-
       raw = "0xf86b820e8485012a05f200831e848094ffe811714ab35360b67ee195ace7c10d93f89d8c80844e71d92d8194a07b8f34a8fb85d850b3be4fc0330382e125e4216df5598c6d2c3bc47954684cf99f35ef53ee007c2f705eca91448b5c86e81d10f659ad868409bac8197bba9814"
       tx = Tx.decode raw
       expect(tx.sender).to eq Util.remove_hex_prefix Address.new("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266").to_s
@@ -115,5 +114,4 @@ describe Tx do
       expect(tx.chain_id).to eq 56
     end
   end
-
 end


### PR DESCRIPTION
Sometimes transaction can have "s" that has 62 char length, instead of 64 chars.

In the "ethereumjs-monorepo"(which is used in web3.js) used the same solution for creation signature
https://github.com/ethereumjs/ethereumjs-monorepo/blob/f39b0b2c826031a3f56b30f154d80c85bebfd611/packages/util/src/signature.ts#L59
```
const signature = Buffer.concat([setLengthLeft(r, 32), setLengthLeft(s, 32)], 64)
```

I've added the example transaction in tests:
```
Raw Transaction:
0xf86b820e8485012a05f200831e848094ffe811714ab35360b67ee195ace7c10d93f89d8c80844e71d92d8194a07b8f34a8fb85d850b3be4fc0330382e125e4216df5598c6d2c3bc47954684cf99f35ef53ee007c2f705eca91448b5c86e81d10f659ad868409bac8197bba9814
```