### PR TITLE
Ability to manual set nonce of tx for transfer, deploy, transact methods was added.

### DIFF
--- a/lib/eth/client.rb
+++ b/lib/eth/client.rb
@@ -106,7 +106,7 @@ module Eth
     # See {#transfer} for params and overloads.
     #
     # @return [String] the transaction hash once it is mined.
-    def transfer_and_wait(destination, amount, sender_key = nil, legacy = false)
+    def transfer_and_wait(destination, amount, sender_key = nil, legacy = false, **kwargs)
       wait_for_tx(transfer(destination, amount, sender_key, legacy))
     end
 
@@ -121,8 +121,9 @@ module Eth
     # @param amount [Integer] the transfer amount in Wei.
     # @param sender_key [Eth::Key] the sender private key.
     # @param legacy [Boolean] enables legacy transactions (pre-EIP-1559).
+    # @param **nonce [Integer] optional specific nonce for transaction.
     # @return [String] the local transaction hash.
-    def transfer(destination, amount, sender_key = nil, legacy = false)
+    def transfer(destination, amount, sender_key = nil, legacy = false, **kwargs)
       params = {
         value: amount,
         to: destination,
@@ -144,7 +145,7 @@ module Eth
         # use the provided key as sender and signer
         params.merge!({
           from: sender_key.address,
-          nonce: get_nonce(sender_key.address),
+          nonce: kwargs[:nonce] || get_nonce(sender_key.address),
         })
         tx = Eth::Tx.new(params)
         tx.sign sender_key
@@ -154,7 +155,7 @@ module Eth
         # use the default account as sender and external signer
         params.merge!({
           from: default_account,
-          nonce: get_nonce(default_account),
+          nonce: kwargs[:nonce] || get_nonce(default_account),
         })
         return eth_send_transaction(params)["result"]
       end
@@ -189,6 +190,7 @@ module Eth
     #   @param **sender_key [Eth::Key] the sender private key.
     #   @param **legacy [Boolean] enables legacy transactions (pre-EIP-1559).
     #   @param **gas_limit [Integer] optional gas limit override for deploying the contract.
+    #   @param **nonce [Integer] optional specific nonce for transaction.
     # @return [String] the transaction hash.
     # @raise [ArgumentError] in case the contract does not have any source.
     def deploy(contract, *args, **kwargs)
@@ -223,7 +225,7 @@ module Eth
         # Uses the provided key as sender and signer
         params.merge!({
           from: kwargs[:sender_key].address,
-          nonce: get_nonce(kwargs[:sender_key].address),
+          nonce: kwargs[:nonce] || get_nonce(kwargs[:sender_key].address),
         })
         tx = Eth::Tx.new(params)
         tx.sign kwargs[:sender_key]
@@ -232,7 +234,7 @@ module Eth
         # Uses the default account as sender and external signer
         params.merge!({
           from: default_account,
-          nonce: get_nonce(default_account),
+          nonce: kwargs[:nonce] || get_nonce(default_account),
         })
         return eth_send_transaction(params)["result"]
       end
@@ -288,6 +290,7 @@ module Eth
     #   @param **legacy [Boolean] enables legacy transactions (pre-EIP-1559).
     #   @param **address [Eth::Address] contract address.
     #   @param **gas_limit [Integer] optional gas limit override for deploying the contract.
+    #   @param **nonce [Integer] optional specific nonce for transaction.
     # @return [Object] returns the result of the transaction.
     def transact(contract, function, *args, **kwargs)
       gas_limit = if kwargs[:gas_limit]
@@ -317,7 +320,7 @@ module Eth
         # use the provided key as sender and signer
         params.merge!({
           from: kwargs[:sender_key].address,
-          nonce: get_nonce(kwargs[:sender_key].address),
+          nonce: kwargs[:nonce] || get_nonce(kwargs[:sender_key].address),
         })
         tx = Eth::Tx.new(params)
         tx.sign kwargs[:sender_key]
@@ -326,7 +329,7 @@ module Eth
         # use the default account as sender and external signer
         params.merge!({
           from: default_account,
-          nonce: get_nonce(default_account),
+          nonce: kwargs[:nonce] || get_nonce(default_account),
         })
         return eth_send_transaction(params)["result"]
       end

--- a/spec/eth/client_spec.rb
+++ b/spec/eth/client_spec.rb
@@ -76,31 +76,31 @@ describe Client do
     it "funds a random account and returns the money" do
       geth_dev_http.transfer_and_wait(test_key.address, 1337 * Unit::ETHER)
       expect(geth_dev_http.get_balance test_key.address).to eq 1337 * Unit::ETHER
-      geth_dev_ipc.transfer_and_wait(geth_dev_ipc.default_account, 42 * Unit::ETHER, test_key)
+      geth_dev_ipc.transfer_and_wait(geth_dev_ipc.default_account, 42 * Unit::ETHER, sender_key: test_key)
       expect(geth_dev_ipc.get_nonce test_key.address).to eq 1
     end
 
     it "funds a random account using legacy transactions" do
-      geth_dev_http.transfer_and_wait(another_key.address, 69 * Unit::ETHER, nil, true)
+      geth_dev_http.transfer_and_wait(another_key.address, 69 * Unit::ETHER, legacy: true)
       expect(geth_dev_http.get_balance another_key.address).to eq 69 * Unit::ETHER
-      geth_dev_ipc.transfer_and_wait(geth_dev_ipc.default_account, 23 * Unit::ETHER, another_key, true)
+      geth_dev_ipc.transfer_and_wait(geth_dev_ipc.default_account, 23 * Unit::ETHER, sender_key: another_key, legacy: true)
       expect(geth_dev_ipc.get_nonce another_key.address).to eq 1
     end
 
     context "when nonce manually set" do
       it "raises exception when nonce incorrect" do
-        expect{
-          geth_dev_http.transfer(another_key.address, 69 * Unit::ETHER, nil, true, nonce: 0)
+        expect {
+          geth_dev_http.transfer(another_key.address, 69 * Unit::ETHER, legacy: true, nonce: 0)
         }.to raise_error(IOError, "nonce too low")
       end
 
       it "funds account twice" do
         inblock_account_nonce = geth_dev_http.get_nonce(geth_dev_http.default_account)
 
-        geth_dev_http.transfer(another_key.address, 69 * Unit::ETHER, nil, true, nonce: inblock_account_nonce)
+        geth_dev_http.transfer(another_key.address, 69 * Unit::ETHER, legacy: true, nonce: inblock_account_nonce)
         inblock_account_nonce += 1
 
-        geth_dev_http.transfer_and_wait(another_key.address, 69 * Unit::ETHER, nil, true, nonce: inblock_account_nonce)
+        geth_dev_http.transfer_and_wait(another_key.address, 69 * Unit::ETHER, legacy: true, nonce: inblock_account_nonce)
         inblock_account_nonce += 1
 
         expect(inblock_account_nonce).to eq(geth_dev_http.get_nonce(geth_dev_http.default_account))
@@ -155,7 +155,7 @@ describe Client do
 
     context "when nonce manually set" do
       it "raises exception when nonce incorrect" do
-        expect{
+        expect {
           geth_dev_http.deploy_and_wait(contract, nonce: 0)
         }.to raise_error(IOError, "nonce too low")
       end
@@ -285,7 +285,7 @@ describe Client do
       let(:contract_address) { geth_dev_http.deploy_and_wait(contract) }
 
       it "raises exception when nonce incorrect" do
-        expect{
+        expect {
           geth_dev_http.transact(contract, "set", 42, address: contract_address, nonce: 0)
         }.to raise_error(IOError, "nonce too low")
       end


### PR DESCRIPTION
Sometimes we need to replace already submitted pending tx, or plan our work with creating array of transactions to send, and it requires manual setting of nonce value. This PR give ability to set tx nonce manually.