### PR TITLE
eth/client: dup params to prevent marshalling on client obj

### DIFF
--- a/lib/eth/client.rb
+++ b/lib/eth/client.rb
@@ -480,6 +480,7 @@ module Eth
 
     # Recursively marshals all request parameters.
     def marshal(params)
+      params = params.dup
       if params.is_a? Array
         return params.map! { |param| marshal(param) }
       elsif params.is_a? Hash

--- a/spec/eth/client_spec.rb
+++ b/spec/eth/client_spec.rb
@@ -311,6 +311,15 @@ describe Client do
 
         expect(inblock_account_nonce).to eq(geth_dev_http.get_nonce(geth_dev_http.default_account))
       end
+
+      it "does not mutate marshalled objects" do
+        params = {
+          from: geth_dev_http.default_account,
+          value: 101,
+        }
+        geth_dev_http.eth_estimate_gas(params)
+        expect(params.dig(:value)).to eq 101
+      end
     end
   end
 


### PR DESCRIPTION
fix #174