### PR TITLE
Tested with Ruby 3.2

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-12]
-        ruby: ['3.0', '3.1']
+        ruby: ['3.0', '3.1', '3.2']
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Ruby 3.2 has been released.
Let's try WASM support and more!
https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/