### PR TITLE
Abi.decoder handles arrays of string and bytes

### DIFF
--- a/lib/eth/abi/decoder.rb
+++ b/lib/eth/abi/decoder.rb
@@ -61,7 +61,7 @@ module Eth
           # decoded dynamic-sized arrays
           (0...l).map { |i| type(nested_sub, arg[32 + nested_sub.size * i, nested_sub.size]) }
         elsif !type.dimensions.empty?
-          l = type.dimensions.last[0]
+          l = type.dimensions.first
           nested_sub = type.nested_sub
 
           # decoded static-size arrays

--- a/lib/eth/abi/decoder.rb
+++ b/lib/eth/abi/decoder.rb
@@ -40,7 +40,7 @@ module Eth
 
             # decoded strings and bytes
             data[0, l]
-          # Case: decoding array of string/bytes
+            # Case: decoding array of string/bytes
           else
             l = Util.deserialize_big_endian_to_int arg[0, 32]
 

--- a/spec/eth/abi_spec.rb
+++ b/spec/eth/abi_spec.rb
@@ -230,6 +230,10 @@ describe Abi do
         "bool[]",
         "address[]",
         "bytes32[]",
+        "bytes[]",
+        "bytes[2]",
+        "string[]",
+        "string[2]",
       ]
       nested_args = [
         [
@@ -245,6 +249,23 @@ describe Abi do
           "\x13\xAE^]b\xD2\xDAD^\x05\b\e\xA8\xD5\x1DK\xBFO\xC7\xDA-ev!\xA1\xABxZ\xA2\x1CE\xEF",
           "\"\x81\x182\xB2\xFC\xC9\e+\xC2.\x19\x83\xAC\xCA\xAC\x05\x18hK\xB5Wf\xBA\x12\xB6\xC8\xA8+Ymp",
           "9\x18\x8C/*\xF7\x9Bpn\x86\b\x05\v\xC2\xA2Q\xD1n\x01w\n\xE6\xA1\xDFo\xBC\xA2.>\x9F\xDD\xE7",
+        ],
+        [
+          "\x13\xAE^]b\xD2\xDAD^\x05\b\e\xA8\xD5\x1DK\xBFO\xC7\xDA-ev!\xA1\xABxZ\xA2\x1CE\xEF",
+          "\"\x81\x182\xB2\xFC\xC9\e+\xC2.\x19\x83\xAC\xCA\xAC\x05\x18hK\xB5Wf\xBA\x12\xB6\xC8\xA8+Ymp",
+        ],
+        [
+          "9\x18\x8C/*\xF7\x9Bpn\x86\b\x05\v\xC2\xA2Q\xD1n\x01w\n\xE6\xA1\xDFo\xBC\xA2.>\x9F\xDD\xE7",
+          "\"\x81\x182\xB2\xFC\xC9\e+\xC2.\x19\x83\xAC\xCA\xAC\x05\x18hK\xB5Wf\xBA\x12\xB6\xC8\xA8+Ymp",
+        ],
+        [
+          "One",
+          "This is a long string that uses multiple EVM words",
+          "And two",
+        ],
+        [
+          "We're",
+          "Happy now",
         ],
       ]
       nested_encoded = Abi.encode nested_types, nested_args

--- a/spec/eth/abi_spec.rb
+++ b/spec/eth/abi_spec.rb
@@ -269,7 +269,8 @@ describe Abi do
           ],
           [
             "0x600087d794f867befc597ebae4200b607d0cd9bd",
-            "0x70005e726762a40057a027a0cb7226b9fe6d7e9a",]
+            "0x70005e726762a40057a027a0cb7226b9fe6d7e9a",
+          ],
         ],
         [
           "\x13\xAE^]b\xD2\xDAD^\x05\b\e\xA8\xD5\x1DK\xBFO\xC7\xDA-ev!\xA1\xABxZ\xA2\x1CE\xEF",

--- a/spec/eth/abi_spec.rb
+++ b/spec/eth/abi_spec.rb
@@ -228,7 +228,11 @@ describe Abi do
 
       nested_types = [
         "bool[]",
+        "bool[2]",
         "address[]",
+        "address[2]",
+        "address[1][]",
+        "address[2][2]",
         "bytes32[]",
         "bytes[]",
         "bytes[2]",
@@ -241,9 +245,31 @@ describe Abi do
           false,
         ],
         [
-          "0x84ad87d794f867befc597ebae4200b607d0cd9bd",
-          "0xb8425e726762a40057a027a0cb7226b9fe6d7e9a",
-          "0xcf960c64b6bb464f30aa2e5a245176438b046e58",
+          false,
+          true,
+        ],
+        [
+          "0x100087d794f867befc597ebae4200b607d0cd9bd",
+          "0x20005e726762a40057a027a0cb7226b9fe6d7e9a",
+          "0x30000c64b6bb464f30aa2e5a245176438b046e58",
+        ],
+        [
+          "0x100087d794f867befc597ebae4200b607d0cd9bd",
+          "0x20005e726762a40057a027a0cb7226b9fe6d7e9a",
+        ],
+        [
+          [
+            "0x30000c64b6bb464f30aa2e5a245176438b046e58",
+          ],
+        ],
+        [
+          [
+            "0x400087d794f867befc597ebae4200b607d0cd9bd",
+            "0x50005e726762a40057a027a0cb7226b9fe6d7e9a",
+          ],
+          [
+            "0x600087d794f867befc597ebae4200b607d0cd9bd",
+            "0x70005e726762a40057a027a0cb7226b9fe6d7e9a",]
         ],
         [
           "\x13\xAE^]b\xD2\xDAD^\x05\b\e\xA8\xD5\x1DK\xBFO\xC7\xDA-ev!\xA1\xABxZ\xA2\x1CE\xEF",


### PR DESCRIPTION
Before

```
> enc = Eth::Abi.encode ["string[]"], [["This is", "a test"]]
=> "\x00\x00\...
> Eth::Abi.decode ["string[]"], enc
.../gems/eth-0.5.10/lib/eth/abi.rb:232:in `decode_type': Wrong data size for string/bytes object (Eth::Abi::DecodingError)
```

After

```
> enc = Eth::Abi.encode ["string[]"], [["This is", "a test"]]
=> "\x00\x00\...
> Eth::Abi.decode ["string[]"], enc
=> [["This is", "a test"]]
```
