### PR TITLE
Manual default_account

### DIFF
--- a/lib/eth/client.rb
+++ b/lib/eth/client.rb
@@ -74,7 +74,7 @@ module Eth
     #
     # @return [Eth::Address] the coinbase account address.
     def default_account
-      raise ArgumentError, "The default account is not available on remote connections!" unless local?
+      raise ArgumentError, "The default account is not available on remote connections!" unless local? || @default_account
       @default_account ||= Address.new eth_coinbase["result"]
     end
 


### PR DESCRIPTION
For remote connection, there is no `Client.default_account` that can be automatically set. However, we are able to define it manually through `Client.default_account=`. This removed the error message and allow calling `Client.default_account` after it was manually set