### PR TITLE
Checking userinfo with the uri method

### DIFF
--- a/lib/eth/client/http.rb
+++ b/lib/eth/client/http.rb
@@ -46,7 +46,7 @@ module Eth
       @host = uri.host
       @port = uri.port
       @ssl = uri.scheme == "https"
-      if Regexp.new(":.*@.*:", Regexp::IGNORECASE).match host
+      if !(uri.user.nil? && uri.password.nil?)
         @user = uri.user
         @password = uri.password
         @uri = URI("#{uri.scheme}://#{uri.user}:#{uri.password}@#{@host}:#{@port}#{uri.path}")


### PR DESCRIPTION
Fixed the basic auth decision in the http client so that it is not affected by ReDoS, which occurs in Ruby 3.1 and below.

close: https://github.com/q9f/eth.rb/security/code-scanning/10

### Ruby 3.1.2
```ruby
irb(main):001:0> RUBY_VERSION
=> "3.1.2"
irb(main):002:0> measure
TIME is added.
=> nil
irb(main):003:0>  /:.*@.*:/i =~ "https://example.com" * 1000
processing time: 0.069204s
=> nil
irb(main):004:0>  /:.*@.*:/i =~ "https://example.com" * 10000
processing time: 4.696144s
=> nil
irb(main):005:0>  /:.*@.*:/i =~ "https://example.com" * 50000
processing time: 119.181579s
=> nil
```

### Ruby 3.2.0
```ruby
irb(main):005:0> RUBY_VERSION
processing time: 0.000062s
=> "3.2.0"
irb(main):006:0> measure
processing time: 0.000090s
=> nil
irb(main):007:0>  /:.*@.*:/i =~ "https://example.com" * 1000
processing time: 0.001817s
=> nil
irb(main):008:0>  /:.*@.*:/i =~ "https://example.com" * 10000
processing time: 0.019022s
=> nil
irb(main):009:0>  /:.*@.*:/i =~ "https://example.com" * 100000
processing time: 0.101864s
=> nil
```