### PR TITLE
Fix the decoding of unsigned transactions

### DIFF
--- a/lib/eth/tx/eip1559.rb
+++ b/lib/eth/tx/eip1559.rb
@@ -186,11 +186,16 @@ module Eth
         # last but not least, set the type.
         @type = TYPE_1559
 
-        # recover sender address
-        v = Chain.to_v recovery_id, chain_id
-        public_key = Signature.recover(unsigned_hash, "#{r.rjust(64, "0")}#{s.rjust(64, "0")}#{v.to_s(16)}", chain_id)
-        address = Util.public_key_to_address(public_key).to_s
-        @sender = Tx.sanitize_address address
+        unless recovery_id.nil?
+          # recover sender address
+          v = Chain.to_v recovery_id, chain_id
+          public_key = Signature.recover(unsigned_hash, "#{r.rjust(64, "0")}#{s.rjust(64, "0")}#{v.to_s(16)}", chain_id)
+          address = Util.public_key_to_address(public_key).to_s
+          @sender = Tx.sanitize_address address
+        else
+          # keep the 'from' field blank
+          @sender = Tx.sanitize_address nil
+        end
       end
 
       # Creates an unsigned copy of a transaction payload.

--- a/lib/eth/tx/eip2930.rb
+++ b/lib/eth/tx/eip2930.rb
@@ -181,11 +181,16 @@ module Eth
         # last but not least, set the type.
         @type = TYPE_2930
 
-        # recover sender address
-        v = Chain.to_v recovery_id, chain_id
-        public_key = Signature.recover(unsigned_hash, "#{r.rjust(64, "0")}#{s.rjust(64, "0")}#{v.to_s(16)}", chain_id)
-        address = Util.public_key_to_address(public_key).to_s
-        @sender = Tx.sanitize_address address
+        unless recovery_id.nil?
+          # recover sender address
+          v = Chain.to_v recovery_id, chain_id
+          public_key = Signature.recover(unsigned_hash, "#{r.rjust(64, "0")}#{s.rjust(64, "0")}#{v.to_s(16)}", chain_id)
+          address = Util.public_key_to_address(public_key).to_s
+          @sender = Tx.sanitize_address address
+        else
+          # keep the 'from' field blank
+          @sender = Tx.sanitize_address nil
+        end
       end
 
       # Creates an unsigned copy of a transaction payload.

--- a/lib/eth/tx/legacy.rb
+++ b/lib/eth/tx/legacy.rb
@@ -154,13 +154,11 @@ module Eth
         _set_signature(v, r, s)
 
         unless chain_id.nil?
-
           # recover sender address
           public_key = Signature.recover(unsigned_hash, "#{r.rjust(64, "0")}#{s.rjust(64, "0")}#{v}", chain_id)
           address = Util.public_key_to_address(public_key).to_s
           @sender = Tx.sanitize_address address
         else
-
           # keep the 'from' field blank
           @sender = Tx.sanitize_address nil
         end

--- a/spec/eth/tx_spec.rb
+++ b/spec/eth/tx_spec.rb
@@ -122,4 +122,17 @@ describe Tx do
       expect(tx.chain_id).to eq 56
     end
   end
+
+  describe '.decode an unsigned transaction' do
+    it "keeps the 'from' field blank" do
+      raw = "0x02f0050584b2d05e00851010b872008303841494caedbd63fb25c3126bfe96c1af208e4688e9817e87f6a3d9c63df00080c0"
+      tx = Tx.decode raw
+
+      expect(tx.signature_y_parity).to eq nil
+      expect(tx.signature_r).to eq 0
+      expect(tx.signature_s).to eq 0
+
+      expect(tx.sender).to eq ""
+    end
+  end
 end

--- a/spec/eth/tx_spec.rb
+++ b/spec/eth/tx_spec.rb
@@ -124,15 +124,30 @@ describe Tx do
   end
 
   describe '.decode an unsigned transaction' do
-    it "keeps the 'from' field blank" do
-      raw = "0x02f0050584b2d05e00851010b872008303841494caedbd63fb25c3126bfe96c1af208e4688e9817e87f6a3d9c63df00080c0"
-      tx = Tx.decode raw
+    context 'EIP-1559' do
+      it "keeps the 'from' field blank" do
+        raw = "0x02f0050584b2d05e00851010b872008303841494caedbd63fb25c3126bfe96c1af208e4688e9817e87f6a3d9c63df00080c0"
+        tx = Tx.decode raw
 
-      expect(tx.signature_y_parity).to eq nil
-      expect(tx.signature_r).to eq 0
-      expect(tx.signature_s).to eq 0
+        expect(tx.signature_y_parity).to eq nil
+        expect(tx.signature_r).to eq 0
+        expect(tx.signature_s).to eq 0
 
-      expect(tx.sender).to eq ""
+        expect(tx.sender).to eq ""
+      end
+    end
+
+    context 'EIP-2930' do
+      it "keeps the 'from' field blank" do
+        raw = "01eb050585037e11d6008303841494caedbd63fb25c3126bfe96c1af208e4688e9817e87f6a3d9c63df00080c0"
+        tx = Tx.decode raw
+
+        expect(tx.signature_y_parity).to eq nil
+        expect(tx.signature_r).to eq 0
+        expect(tx.signature_s).to eq 0
+
+        expect(tx.sender).to eq ""
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, the transaction decoding methods (both for EIP-1559 and EIP-2930) try to recover a sender address for unsigned transactions, which results in the following error:

```
lib/eth/chain.rb:161:in `+': nil can't be coerced into Integer (TypeError)

        v = 2 * chain_id + 35 + recovery_id
                                ^^^^^^^^^^^
```

This PR fixes this issue by checking if `recovery_id` is present.