### PR TITLE
eth/api: remove coinbase as default account

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -49,5 +49,9 @@ jobs:
       run: |
         bundle exec rspec
       env:
-        COVERAGE: true
         INFURA_TOKEN: ${{ secrets.INFURA_TOKEN }}
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/lib/eth/api.rb
+++ b/lib/eth/api.rb
@@ -115,7 +115,6 @@ module Eth
       "eth_blockNumber",
       "eth_call",
       "eth_chainId",
-      "eth_coinbase",
       "eth_compileLLL",
       "eth_compileSerpent",
       "eth_compileSolidity",

--- a/lib/eth/client.rb
+++ b/lib/eth/client.rb
@@ -25,7 +25,7 @@ module Eth
     # The connected network's chain ID.
     attr_reader :chain_id
 
-    # The connected network's client coinbase.
+    # The connected network's client default account.
     attr_accessor :default_account
 
     # The default transaction max priority fee per gas in Wei, defaults to {Tx::DEFAULT_PRIORITY_FEE}.
@@ -62,15 +62,15 @@ module Eth
       @max_fee_per_gas = Tx::DEFAULT_GAS_PRICE
     end
 
-    # Gets the default account (coinbase) of the connected client.
+    # Gets the default account (first account) of the connected client.
     #
     # **Note**, that many remote providers (e.g., Infura) do not provide
     # any accounts.
     #
-    # @return [Eth::Address] the coinbase account address.
+    # @return [Eth::Address] the default account address.
     def default_account
       raise ArgumentError, "The default account is not available on remote connections!" unless local? || @default_account
-      @default_account ||= Address.new eth_coinbase["result"]
+      @default_account ||= Address.new eth_accounts["result"].first
     end
 
     # Gets the chain ID of the connected network.
@@ -108,7 +108,7 @@ module Eth
     end
 
     # Simply transfer Ether to an account and waits for it to be mined.
-    # Uses `eth_coinbase` and external signer if no sender key is
+    # Uses `eth_accounts` and external signer if no sender key is
     # provided.
     #
     # See {#transfer} for params and overloads.
@@ -119,7 +119,7 @@ module Eth
     end
 
     # Simply transfer Ether to an account without any call data or
-    # access lists attached. Uses `eth_coinbase` and external signer
+    # access lists attached. Uses `eth_accounts` and external signer
     # if no sender key is provided.
     #
     # **Note**, that many remote providers (e.g., Infura) do not provide
@@ -179,7 +179,7 @@ module Eth
     end
 
     # Deploys a contract and waits for it to be mined. Uses
-    # `eth_coinbase` or external signer if no sender key is provided.
+    # `eth_accounts` or external signer if no sender key is provided.
     #
     # See {#deploy} for params and overloads.
     #
@@ -190,7 +190,7 @@ module Eth
       contract.address = Address.new(addr).to_s
     end
 
-    # Deploys a contract. Uses `eth_coinbase` or external signer
+    # Deploys a contract. Uses `eth_accounts` or external signer
     # if no sender key is provided.
     #
     # **Note**, that many remote providers (e.g., Infura) do not provide

--- a/spec/eth/solidity_spec.rb
+++ b/spec/eth/solidity_spec.rb
@@ -34,7 +34,9 @@ describe Solidity do
     result = solc.compile contract
     expect(result["DepositContract"]).to be
     payload = result["DepositContract"]["bin"]
-    expect(payload).to start_with "608060405234"
+    expect(payload).to start_with "60"
+    expect(payload).to end_with "33"
+    expect(payload.length).to eq 6180
     params = {
       from: geth.default_account,
       priority_fee: 0,

--- a/spec/eth/solidity_spec.rb
+++ b/spec/eth/solidity_spec.rb
@@ -36,7 +36,6 @@ describe Solidity do
     payload = result["DepositContract"]["bin"]
     expect(payload).to start_with "60"
     expect(payload).to end_with "33"
-    expect(payload.length).to eq 6180
     params = {
       from: geth.default_account,
       priority_fee: 0,

--- a/spec/eth/solidity_spec.rb
+++ b/spec/eth/solidity_spec.rb
@@ -34,7 +34,7 @@ describe Solidity do
     result = solc.compile contract
     expect(result["DepositContract"]).to be
     payload = result["DepositContract"]["bin"]
-    expect(payload).to start_with "604060808152"
+    expect(payload).to start_with "608060405234"
     params = {
       from: geth.default_account,
       priority_fee: 0,


### PR DESCRIPTION
the api will be removed in geth 1.14.x