### PR TITLE
Fix undefined method `raise_error' for an instance of Eth::Tx::Eip1559 (NoMethodError)

### DIFF
--- a/lib/eth/tx/eip1559.rb
+++ b/lib/eth/tx/eip1559.rb
@@ -180,7 +180,7 @@ module Eth
           # allows us to force-setting a signature if the transaction is signed already
           _set_signature(recovery_id, r, s)
         else
-          raise_error DecoderError, "Cannot decode EIP-1559 payload!"
+          raise DecoderError, "Cannot decode EIP-1559 payload!"
         end
 
         # last but not least, set the type.

--- a/lib/eth/tx/eip2930.rb
+++ b/lib/eth/tx/eip2930.rb
@@ -175,7 +175,7 @@ module Eth
           # allows us to force-setting a signature if the transaction is signed already
           _set_signature(recovery_id, r, s)
         else
-          raise_error DecoderError, "Cannot decode EIP-2930 payload!"
+          raise DecoderError, "Cannot decode EIP-2930 payload!"
         end
 
         # last but not least, set the type.


### PR DESCRIPTION
I think the line `raise_error DecoderError, "Cannot decode EIP-2930 payload!"` was intended to be `raise DecoderError, "Cannot decode EIP-2930 payload!"` but didn't make it due to an accidental copy-paste from rspec.

`raise_error` isn't defined anywhere in the project and so this line currently doesn't work. Switching to `raise` will make it work as expected.