### PR TITLE
Update encoder.rb to limit hex false positives

### DIFF
--- a/lib/eth/abi/encoder.rb
+++ b/lib/eth/abi/encoder.rb
@@ -285,13 +285,9 @@ module Eth
       # The ABI encoder needs to be able to determine between a hex `"123"`
       # and a binary `"123"` string.
       def handle_hex_string(arg, type)
-        if Util.prefixed? arg or
-           (arg.size === type.sub_type.to_i * 2 and Util.hex? arg)
-
+        if (arg.size === type.sub_type.to_i * 2 and Util.hex? arg)
           # There is no way telling whether a string is hex or binary with certainty
-          # in Ruby. Therefore, we assume a `0x` prefix to indicate a hex string.
-          # Additionally, if the string size is exactly the double of the expected
-          # binary size, we can assume a hex value.
+          # in Ruby.
           Util.hex_to_bin arg
         else
 


### PR DESCRIPTION
Looking at `Util.prefixed? arg` to determine whether to treat something as hex makes it impossible to encode anything that starts with the bytes `[48,120]`, which is not that infrequent.

Also, I don't think we get any benefit from this part of the conditional anyway since if the string isn't both hex chars and 2x the input size things will fail anyway.

Longer term it might be beneficial to force the user to specify the encoding.

Thanks!