### PR TITLE
Adds support to check for the ethereum "null address"

### DIFF
--- a/lib/eth/address.rb
+++ b/lib/eth/address.rb
@@ -17,6 +17,7 @@ module Eth
 
   # The {Eth::Address} class to handle checksummed Ethereum addresses.
   class Address
+    NULL = "0x0000000000000000000000000000000000000000"
 
     # Provides a special checksum error if EIP-55 is violated.
     class CheckSumError < StandardError; end
@@ -49,6 +50,13 @@ module Eth
       else
         checksum_matches?
       end
+    end
+
+    # Checks that the address is the null address.
+    # 
+    # @return [Boolean] true if the address is the null address.
+    def null?
+      address == NULL
     end
 
     # Generate a checksummed address.

--- a/spec/eth/address_spec.rb
+++ b/spec/eth/address_spec.rb
@@ -8,7 +8,6 @@ describe Address do
     subject(:bob) { Address.new "0x7291d3cd257053bac810ee2c55fd7c154bd455af" }
 
     it "generates functional addresses" do
-
       # generates a functional key for alice of type Address
       expect(alice).to be_an_instance_of Address
       expect(bob).to be_an_instance_of Address
@@ -18,7 +17,6 @@ describe Address do
     end
 
     it "prefixes an unprefixed address" do
-
       # ensure both addresses contains the 0x prefix
       # alice's address was initialized without 0x
       expect(alice.address).to start_with "0x"
@@ -121,6 +119,28 @@ describe Address do
         end
 
         expect { Address.new "foo" }.to raise_error Address::CheckSumError, "Unknown address type foo!"
+      end
+    end
+  end
+
+  describe ".null?" do
+    let(:null) { Address::NULL }
+    let(:addresses) do
+      [
+        "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed",
+        "0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359",
+        "0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb",
+        "0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb",
+      ]
+    end
+
+    it "returns true for the null address" do
+      expect(Address.new(null)).to be_null
+    end
+
+    it "returns false for a valid address" do
+      addresses.each do |address|
+        expect(Address.new(address)).not_to be_null
       end
     end
   end


### PR DESCRIPTION
* Many dreams have gone to the null address to die, this provides a simple check for developers to opt in to avoiding that fate.

Many ETH address validators specifically reject the null address to avoid potentially allowing unexpected behavior, but I didn't change any defaults to how this library functions.