### PR TITLE
eth/util: fix single-byte hex-string nibbles

### DIFF
--- a/lib/eth/util.rb
+++ b/lib/eth/util.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# -*- encoding : ascii-8bit -*-
+
 require "digest/keccak"
 
 # Provides the {Eth} module.
@@ -48,7 +50,7 @@ module Eth
     # @raise [TypeError] if value is not a string.
     def bin_to_hex(bin)
       raise TypeError, "Value must be an instance of String" unless bin.instance_of? String
-      bin.unpack("H*").first
+      hex = bin.unpack("H*").first
     end
 
     # Packs a hexa-decimal string into a binary string. Also works with
@@ -61,7 +63,8 @@ module Eth
       raise TypeError, "Value must be an instance of String" unless hex.instance_of? String
       hex = remove_hex_prefix hex
       raise TypeError, "Non-hexadecimal digit found" unless hex? hex
-      [hex].pack("H*")
+      hex = "0#{hex}" if hex.size % 2 != 0
+      bin = [hex].pack("H*")
     end
 
     # Prefixes a hexa-decimal string with `0x`.

--- a/spec/eth/util_spec.rb
+++ b/spec/eth/util_spec.rb
@@ -80,6 +80,11 @@ describe Util do
       expect { Util.hex_to_bin "\x00\x00" }.to raise_error TypeError
       expect { Util.hex_to_bin 1234 }.to raise_error TypeError
     end
+
+    it "can convert back and forth" do
+      expect(Util.bin_to_hex Util.hex_to_bin "a").to eq "0a"
+      expect(Util.hex_to_bin Util.bin_to_hex "a").to eq "a"
+    end
   end
 
   describe ".prefix_hex .remove_hex_prefix" do


### PR DESCRIPTION
fix single-byte hex-string nibbles:

```ruby
[1] pry(main)> Util.hex_to_bin "a"
=> "\n"
[2] pry(main)> Util.bin_to_hex "\n"
=> "0a"
[3] pry(main)> Util.bin_to_hex Util.hex_to_bin "a"
=> "0a"
```

this fixes the bug raised in #292 

```ruby
[1] pry(main)> Rlp.encode "a"
=> "a"
[2] pry(main)> Rlp.decode "a"
=> "\n"
[3] pry(main)> Rlp.decode Rlp.encode "a"
=> "\n"
[4] pry(main)> Util.bin_to_hex Rlp.decode Rlp.encode "a"
=> "0a"
```