### PR TITLE
Move the tests that are failing due to a geth upgrade to pending 

### DIFF
--- a/spec/eth/client_spec.rb
+++ b/spec/eth/client_spec.rb
@@ -124,6 +124,7 @@ describe Client do
 
     context "when nonce manually set" do
       it "raises exception when nonce incorrect" do
+        pending("https://github.com/q9f/eth.rb/issues/329")
         expect {
           geth_http.transfer(another_key.address, 69 * Unit::ETHER, legacy: true, nonce: 0)
         }.to raise_error(IOError, /nonce too low: next nonce [0-9]+, tx nonce [0-9]+/)
@@ -190,6 +191,8 @@ describe Client do
 
     context "when nonce manually set" do
       it "raises exception when nonce incorrect" do
+        pending("https://github.com/q9f/eth.rb/issues/329")
+        fail "failing here so we don't get a timeout.  Remove this line to debug the test and expect behaviour."
         expect {
           geth_http.deploy_and_wait(contract, nonce: 0)
         }.to raise_error(IOError, /nonce too low: next nonce [0-9]+, tx nonce [0-9]+/)
@@ -396,6 +399,7 @@ describe Client do
       let(:contract_address) { geth_http.deploy_and_wait(contract) }
 
       it "raises exception when nonce incorrect" do
+        pending("https://github.com/q9f/eth.rb/issues/329")
         expect {
           geth_http.transact(contract, "set", 42, address: contract_address, nonce: 0)
         }.to raise_error(IOError, /nonce too low: next nonce [0-9]+, tx nonce [0-9]+/)


### PR DESCRIPTION
Move the tests that are failing due to a geth upgrade to pending so they can be resolved and tracked without blocking other changes.

Related to #329 