### PR TITLE
Add methods to encode function call and decode its result

### DIFF
--- a/lib/eth/abi.rb
+++ b/lib/eth/abi.rb
@@ -44,6 +44,7 @@ module Eth
       return solidity_packed(types, args) if packed
       types = [types] unless types.instance_of? Array
       args = [args] unless args.instance_of? Array
+      raise ArgumentError, "Types and values must be the same length" if types.length != args.length
 
       # parse all types
       parsed_types = types.map { |t| Type === t ? t : Type.parse(t) }

--- a/lib/eth/client.rb
+++ b/lib/eth/client.rb
@@ -262,7 +262,7 @@ module Eth
             from: kwargs[:from],
             gas: kwargs[:gas],
             gasPrice: kwargs[:gas_price],
-            value: kwargs[:value]
+            value: kwargs[:value],
           }.compact
         )["result"]
       )

--- a/lib/eth/contract.rb
+++ b/lib/eth/contract.rb
@@ -106,6 +106,18 @@ module Eth
       end
     end
 
+    # Finds a function by name.
+    #
+    # @param name [String] function name.
+    # @param args [Integer, nil] number of arguments of a function.
+    # @return [Eth::Contract::Function] function object.
+    # @raise [ArgumentError] if function not found.
+    def function(name, args: nil)
+      functions.find do |f|
+        f.name == name && (args.nil? || args == f.inputs.size)
+      end || raise(ArgumentError, "this function does not exist!")
+    end
+
     # Create meta classes for smart contracts.
     def build
       class_name = @name
@@ -119,6 +131,7 @@ module Eth
         def_delegators :parent, :events
         def_delegators :parent, :address, :address=
         def_delegator :parent, :functions
+        def_delegator :parent, :function
         def_delegator :parent, :constructor_inputs
         define_method :parent do
           parent

--- a/lib/eth/contract/function.rb
+++ b/lib/eth/contract/function.rb
@@ -53,5 +53,26 @@ module Eth
     def self.encoded_function_signature(signature)
       Util.bin_to_hex Util.keccak256(signature)[0..3]
     end
+
+    # Encodes a function call arguments
+    #
+    # @param args [Array] function arguments
+    # @return [String] encoded function call data
+    def encode_call(*args)
+      types = inputs.map(&:parsed_type)
+      encoded_str = Util.bin_to_hex(Eth::Abi.encode(types, args))
+      Util.prefix_hex(signature + (encoded_str.empty? ? "0" * 64 : encoded_str))
+    end
+
+    # Decodes a function call result
+    #
+    # @param data [String] eth_call result in hex format
+    # @return [Array]
+    def decode_call_result(data)
+      return nil if data == "0x"
+
+      types = outputs.map { |i| i.type }
+      Eth::Abi.decode(types, data)
+    end
   end
 end

--- a/spec/eth/contract/function_spec.rb
+++ b/spec/eth/contract/function_spec.rb
@@ -53,4 +53,20 @@ describe Contract::Function do
       expect(Contract::Function.encoded_function_signature(signature)).to eq("1b9faea1")
     end
   end
+
+  describe "#encode_call" do
+    it "encodes function arguments" do
+      expect(
+        functions[0].encode_call("0xA64d0659990256F7669cf3BcF422998aAE7536f5", "0x6f813e6430a223e3ac285144fa9857cb38a642a6")
+      ).to eq("0xdd62ed3e000000000000000000000000a64d0659990256f7669cf3bcf422998aae7536f50000000000000000000000006f813e6430a223e3ac285144fa9857cb38a642a6")
+    end
+  end
+
+  describe "#decode_call_result" do
+    it "decodes call result" do
+      expect(
+        functions[0].decode_call_result("0x00000000000000000000000000000000000000000000000000000000000000af")
+      ).to eq([175])
+    end
+  end
 end

--- a/spec/eth/contract_spec.rb
+++ b/spec/eth/contract_spec.rb
@@ -117,4 +117,20 @@ describe Contract do
       expect(geth.call(cont, "retrieveMyArray", 2)).to eq "0x852b8A5b155C3aaB8EafE1BAd2c0E2D3D643F69d".downcase
     end
   end
+
+  describe "#function" do
+    it "finds function by name" do
+      expect(dummy_contract.function("set").name).to eq("set")
+      expect(dummy_contract.function("set", args: 1).name).to eq("set")
+    end
+
+    it "raises in args size mismatch" do
+      expect do
+        dummy_contract.function("set", args: 0)
+      end.to raise_error("this function does not exist!")
+      expect do
+        dummy_contract.function("get", args: 1)
+      end.to raise_error("this function does not exist!")
+    end
+  end
 end


### PR DESCRIPTION
In my case, I need to mock `eth_call` RPC requests, so I need to encode call args and decode call result to be public functions.