### PR TITLE
Allow to use chains with id > 4294967295

### DIFF
--- a/lib/eth/chain.rb
+++ b/lib/eth/chain.rb
@@ -161,6 +161,9 @@ module Eth
     # Chain ID for Holesovice testnet.
     HOLESKY = HOLESOVICE
 
+    # Chain ID for Basecamp testnet.
+    BASECAMP = 123420001114.freeze
+
     # Chain ID for the geth private network preset.
     PRIVATE_GETH = 1337.freeze
 

--- a/lib/eth/key.rb
+++ b/lib/eth/key.rb
@@ -75,7 +75,7 @@ module Eth
       signature = compact.bytes
       v = Chain.to_v recovery_id, chain_id
       leading_zero = true
-      [v].pack("N").unpack("C*").each do |byte|
+      [v].pack("Q>").unpack("C*").each do |byte|
         leading_zero = false if byte > 0 and leading_zero
         signature.append byte unless leading_zero and byte === 0
       end

--- a/spec/eth/chain_spec.rb
+++ b/spec/eth/chain_spec.rb
@@ -52,6 +52,7 @@ describe Chain do
       expect(Chain::SEPOLIA).to eq 11155111
       expect(Chain::HOLESOVICE).to eq 11166111
       expect(Chain::HOLESKY).to eq 11166111
+      expect(Chain::BASECAMP).to eq 123420001114
 
       # Chain IDs for selected private networks
       expect(Chain::PRIVATE_GETH).to eq 1337

--- a/spec/eth/signature_spec.rb
+++ b/spec/eth/signature_spec.rb
@@ -254,5 +254,16 @@ describe Signature do
       expect(Signature.personal_recover msg, sig, chain_id).to eq key.public_hex
       expect(Signature.verify msg, sig, key.public_hex, chain_id).to be_truthy
     end
+
+    it "can sign and verify for chain IDs > 4294967295" do
+      key = Key.new priv: "8e091dfb95a1b03cdd22890248c3f1b0f048186f2f3aa93257bc5271339eb306"
+      msg = "Hello, Basecamp!"
+      chain_id = Chain::BASECAMP
+      sig = key.personal_sign msg, chain_id
+      r, s, v = Signature.dissect sig
+      expect(Chain.to_chain_id v.to_i(16)).to eq chain_id
+      expect(Signature.personal_recover msg, sig, chain_id).to eq key.public_hex
+      expect(Signature.verify msg, sig, key.public_hex, chain_id).to be_truthy
+    end
   end
 end


### PR DESCRIPTION
Signatures for chains with id > 4294967295 can be created and verified correctly.
#336