### PR TITLE
Handle uppercase hex prefixes

### DIFF
--- a/lib/eth/util.rb
+++ b/lib/eth/util.rb
@@ -72,8 +72,7 @@ module Eth
     # @param hex [String] a hex-string to be prefixed.
     # @return [String] a prefixed hex-string.
     def prefix_hex(hex)
-      return hex if prefixed? hex
-      return "0x#{hex}"
+      "0x#{remove_hex_prefix hex}"
     end
 
     # Removes the `0x` prefix of a hexa-decimal string.
@@ -108,7 +107,7 @@ module Eth
     # @param hex [String] a string to be checked.
     # @return [String] a match if true; `nil` if not.
     def prefixed?(hex)
-      hex.match /\A0x/
+      hex.match /\A0x/i
     end
 
     # Serializes an unsigned integer to big endian.

--- a/spec/eth/address_spec.rb
+++ b/spec/eth/address_spec.rb
@@ -22,6 +22,11 @@ describe Address do
       expect(alice.address).to start_with "0x"
       expect(bob.address).to start_with "0x"
     end
+
+    it "accepts an address with upper-case 0X prefix" do
+      carol = Address.new "0X7291d3cd257053bac810ee2c55fd7c154bd455af"
+      expect(carol.address).to start_with "0x"
+    end
   end
 
   describe ".valid?" do

--- a/spec/eth/util_spec.rb
+++ b/spec/eth/util_spec.rb
@@ -87,22 +87,27 @@ describe Util do
     end
   end
 
-  describe ".prefix_hex .remove_hex_prefix" do
+    describe ".prefix_hex .remove_hex_prefix" do
     it "ensures that a hex value has 0x at the beginning" do
       expect(Util.prefix_hex "abc").to eq "0xabc"
       expect(Util.prefix_hex "0xabc").to eq "0xabc"
     end
 
-    it "ensures we can remove 0x hex prefixes" do
-      expect(Util.remove_hex_prefix "abc").to eq "abc"
-      expect(Util.remove_hex_prefix "0xabc").to eq "abc"
-    end
+      it "ensures we can remove 0x hex prefixes" do
+        expect(Util.remove_hex_prefix "abc").to eq "abc"
+        expect(Util.remove_hex_prefix "0xabc").to eq "abc"
+      end
 
-    it "does not reformat the hex or remove leading zeros" do
-      expect(Util.prefix_hex "0123").to eq "0x0123"
-      expect(Util.remove_hex_prefix "0x0123").to eq "0123"
+      it "does not reformat the hex or remove leading zeros" do
+        expect(Util.prefix_hex "0123").to eq "0x0123"
+        expect(Util.remove_hex_prefix "0x0123").to eq "0123"
+      end
+
+      it "handles upper-case 0X prefixes" do
+        expect(Util.prefix_hex "0Xabc").to eq "0xabc"
+        expect(Util.remove_hex_prefix "0Xabc").to eq "abc"
+      end
     end
-  end
 
   describe ".hex .prefixed" do
     it "can determine prefixed and unprefixed hexa-decimal strings" do
@@ -111,9 +116,10 @@ describe Util do
       expect(Util.hex? "f77a7b601a1902ce8fb866fb304527f6").to be_truthy
       expect(Util.hex? "B7ktIsrmF4DCxsOVhRmmBMh8ArXRs2I6").to be_falsy
 
-      # Ensure we can detect hexa-decimal prefixes.
-      expect(Util.prefixed? "0x94ead6c8ca752be9383610ee078961").to be_truthy
-      expect(Util.prefixed? "563df9c4690a3be20b5abc9c6705c4c7").to be_falsy
+        # Ensure we can detect hexa-decimal prefixes.
+        expect(Util.prefixed? "0x94ead6c8ca752be9383610ee078961").to be_truthy
+        expect(Util.prefixed? "0X94ead6c8ca752be9383610ee078961").to be_truthy
+        expect(Util.prefixed? "563df9c4690a3be20b5abc9c6705c4c7").to be_falsy
 
       # Ensure we can add and remove prefixes.
       expect(Util.prefixed? Util.remove_hex_prefix "0xa6cae631a6b7121648cc940613208e").to be_falsy


### PR DESCRIPTION
## Summary
- canonicalize hex prefixes to `0x`
- treat `0X` inputs as prefixed hex strings
- test handling of upper-case prefixes in util and address

## Testing
- `bundle exec rspec` *(fails: Eth::Contract.from_file .from_bin .from_abi arguments are missing, Eth::Ens::Resolver text gets text records for different keys, Eth::Key::Decrypter official ethereum test fixtures can decrypt the test cases, Eth::Key::Encrypter.perform official ethereum test fixtures can encrypt the test cases, Eth::Rlp.encode .decode can encode rlp, Eth::Solidity finds a solc compiler, Eth::Solidity compiles the dummy contract, Eth::Solidity compiles the greeter contract, Eth::Solidity deploys an ethereum-consensus deposit contract, Eth::Solidity handles file-system errors, Eth::Solidity handles compiler errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fbda43624832bb35e862bf1494bca