### PR TITLE
Fix receiver option spelling

### DIFF
--- a/lib/eth/tx/eip1559.rb
+++ b/lib/eth/tx/eip1559.rb
@@ -78,7 +78,7 @@ module Eth
       # @option params [Integer] :max_gas_fee the max transaction fee per gas.
       # @option params [Integer] :gas_limit the gas limit.
       # @option params [Eth::Address] :from the sender address.
-      # @option params [Eth::Address] :to the reciever address.
+      # @option params [Eth::Address] :to the receiver address.
       # @option params [Integer] :value the transaction value.
       # @option params [String] :data the transaction data payload.
       # @option params [Array] :access_list an optional access list.

--- a/lib/eth/tx/eip2930.rb
+++ b/lib/eth/tx/eip2930.rb
@@ -76,7 +76,7 @@ module Eth
       # @option params [Integer] :gas_price the gas price.
       # @option params [Integer] :gas_limit the gas limit.
       # @option params [Eth::Address] :from the sender address.
-      # @option params [Eth::Address] :to the reciever address.
+      # @option params [Eth::Address] :to the receiver address.
       # @option params [Integer] :value the transaction value.
       # @option params [String] :data the transaction data payload.
       # @option params [Array] :access_list an optional access list.

--- a/lib/eth/tx/eip7702.rb
+++ b/lib/eth/tx/eip7702.rb
@@ -196,7 +196,7 @@ module Eth
       # @option params [Integer] :max_gas_fee the max transaction fee per gas.
       # @option params [Integer] :gas_limit the gas limit.
       # @option params [Eth::Address] :from the sender address.
-      # @option params [Eth::Address] :to the reciever address.
+      # @option params [Eth::Address] :to the receiver address.
       # @option params [Integer] :value the transaction value.
       # @option params [String] :data the transaction data payload.
       # @option params [Array] :access_list an optional access list.

--- a/lib/eth/tx/legacy.rb
+++ b/lib/eth/tx/legacy.rb
@@ -68,7 +68,7 @@ module Eth
       # @option params [Integer] :gas_price the gas price.
       # @option params [Integer] :gas_limit the gas limit.
       # @option params [Eth::Address] :from the sender address.
-      # @option params [Eth::Address] :to the reciever address.
+      # @option params [Eth::Address] :to the receiver address.
       # @option params [Integer] :value the transaction value.
       # @option params [String] :data the transaction data payload.
       # @param chain_id [Integer] the EIP-155 Chain ID.


### PR DESCRIPTION
- correct `receiver` option descriptions in transaction classes
