### PR TITLE
Handle hex input consistently in int_to_big_endian

### DIFF
--- a/lib/eth/util.rb
+++ b/lib/eth/util.rb
@@ -129,7 +129,7 @@ module Eth
     # @param num [Integer] integer to be converted.
     # @return [String] packed, big-endian integer string.
     def int_to_big_endian(num)
-      hex = num.to_s(16) unless hex? num
+      hex = hex?(num) ? remove_hex_prefix(num) : num.to_s(16)
       hex = "0#{hex}" if hex.size.odd?
       hex_to_bin hex
     end


### PR DESCRIPTION
- Ensure int_to_big_endian initializes `hex` for numeric and hex string inputs
