### PR TITLE
Handle hex string inputs in big-endian conversion

### DIFF
--- a/lib/eth/util.rb
+++ b/lib/eth/util.rb
@@ -129,7 +129,11 @@ module Eth
     # @param num [Integer] integer to be converted.
     # @return [String] packed, big-endian integer string.
     def int_to_big_endian(num)
-      hex = num.to_s(16) unless hex? num
+      hex = if hex? num
+        remove_hex_prefix num
+      else
+        num.to_s(16)
+      end
       hex = "0#{hex}" if hex.size.odd?
       hex_to_bin hex
     end

--- a/lib/eth/util.rb
+++ b/lib/eth/util.rb
@@ -129,10 +129,10 @@ module Eth
     # @return [String] packed, big-endian integer string.
     def int_to_big_endian(num)
       hex = if hex? num
-        remove_hex_prefix num
-      else
-        num.to_s(16)
-      end
+          remove_hex_prefix num
+        else
+          num.to_s(16)
+        end
       hex = "0#{hex}" if hex.size.odd?
       hex_to_bin hex
     end

--- a/spec/eth/util_spec.rb
+++ b/spec/eth/util_spec.rb
@@ -145,6 +145,11 @@ describe Util do
       end
     end
 
+    it "converts hex strings to big endian" do
+      expect(Util.int_to_big_endian("0x10")).to eq "\x10"
+      expect(Util.int_to_big_endian("10")).to eq "\x10"
+    end
+
     it "can raises if integers are invalid" do
       negative_ints = [-1, -100, -255, -256, -2342423]
       negative_ints.each do |n|


### PR DESCRIPTION
- allow `Util.int_to_big_endian` to accept prefixed and unprefixed hex strings
- test hex string support for `Util.int_to_big_endian`
