### PR TITLE
Support Solidity custom errors per ERC-6093

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.5.15]
+### Added
+* Eth/contract: support solidity custom errors as per ERC-6093 [#344](https://github.com/q9f/eth.rb/pull/344)
+
 ## [0.5.14]
 ### Added
 * Add ability to decode event parameters using ABI reference. [#328](https://github.com/q9f/eth.rb/pull/328)
 * Add support for EIP-7702 transactions  [#320](https://github.com/q9f/eth.rb/pull/320)
 * Eth/abi: implement packed encoder [#310](https://github.com/q9f/eth.rb/pull/310)
-* Support Solidity custom errors as per EIP-6093 [#323](https://github.com/q9f/eth.rb/issues/323)
 
 ### Changed
 * Chore: run rufo, add docs [#332](https://github.com/q9f/eth.rb/pull/332)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 * Add ability to decode event parameters using ABI reference. [#328](https://github.com/q9f/eth.rb/pull/328)
 * Add support for EIP-7702 transactions  [#320](https://github.com/q9f/eth.rb/pull/320)
 * Eth/abi: implement packed encoder [#310](https://github.com/q9f/eth.rb/pull/310)
+* Support Solidity custom errors as per EIP-6093 [#323](https://github.com/q9f/eth.rb/issues/323)
 
 ### Changed
 * Chore: run rufo, add docs [#332](https://github.com/q9f/eth.rb/pull/332)

--- a/lib/eth/contract/error.rb
+++ b/lib/eth/contract/error.rb
@@ -1,0 +1,62 @@
+# Copyright (c) 2016-2025 The Ruby-Eth Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- encoding : ascii-8bit -*-
+
+# Provides the {Eth} module.
+module Eth
+  # Provide classes for contract custom errors.
+  class Contract::Error
+    attr_accessor :name, :inputs, :signature, :error_string
+
+    # Constructor of the {Eth::Contract::Error} class.
+    #
+    # @param data [Hash] contract abi data for the error.
+    def initialize(data)
+      @name = data["name"]
+      @inputs = data.fetch("inputs", []).map do |input|
+        Eth::Contract::FunctionInput.new(input)
+      end
+      @error_string = self.class.calc_signature(@name, @inputs)
+      @signature = self.class.encoded_error_signature(@error_string)
+    end
+
+    # Creates error strings.
+    #
+    # @param name [String] error name.
+    # @param inputs [Array<Eth::Contract::FunctionInput>] error input class list.
+    # @return [String] error string.
+    def self.calc_signature(name, inputs)
+      "#{name}(#{inputs.map { |x| x.parsed_type.to_s }.join(",")})"
+    end
+
+    # Encodes an error signature.
+    #
+    # @param signature [String] error signature.
+    # @return [String] encoded error signature string.
+    def self.encoded_error_signature(signature)
+      Util.prefix_hex(Util.bin_to_hex(Util.keccak256(signature)[0..3]))
+    end
+
+    # Decodes a revert error payload.
+    #
+    # @param data [String] the hex-encoded revert data including selector.
+    # @return [Array] decoded error arguments.
+    def decode(data)
+      types = inputs.map(&:type)
+      payload = "0x" + data[10..]
+      Eth::Abi.decode(types, payload)
+    end
+  end
+end

--- a/spec/eth/contract/error_spec.rb
+++ b/spec/eth/contract/error_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Client do
+describe Contract do
   describe "#call with custom error" do
     let(:client) { Client.new(nil) }
 

--- a/spec/eth/custom_error_spec.rb
+++ b/spec/eth/custom_error_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe Client do
+  describe "#call with custom error" do
+    let(:client) { Client.new(nil) }
+
+    let(:abi) do
+      [
+        { "type" => "function", "name" => "foo", "inputs" => [], "outputs" => [] },
+        {
+          "type" => "error",
+          "name" => "Unauthorized",
+          "inputs" => [{ "name" => "addr", "type" => "address" }],
+        },
+      ]
+    end
+
+    let(:contract) do
+      Contract.from_abi(abi: abi, address: Address::ZERO, name: "Foo")
+    end
+
+    let(:error_data) do
+      sig = contract.errors.first.signature
+      encoded = Util.bin_to_hex(Abi.encode(["address"], [Address::ZERO]))
+      sig + encoded
+    end
+
+    it "decodes custom error data" do
+      allow(client).to receive(:eth_call).and_raise(Client::RpcError.new("execution reverted", error_data))
+      expect { client.call(contract, "foo") }.to raise_error(Client::ContractExecutionError, "execution reverted: Unauthorized(0x0000000000000000000000000000000000000000)")
+    end
+  end
+end


### PR DESCRIPTION
- add RpcError for rich RPC error info and decode custom errors
- handle `error` ABI entries and provide decoder
- cover decoding of custom errors in tests
