### PR TITLE
Allow signing transactions with external signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,24 +62,6 @@ and the
 [![Usage Wiki](https://img.shields.io/badge/usage-WIKI-blue)](https://github.com/q9f/eth.rb/wiki)
 for all the details and example snippets.
 
-### Signing transactions with external providers
-
-Keys can be kept with a remote signer or "key-as-a-service" provider. Build an
-unsigned transaction locally, obtain the signature from the external service and
-attach it before broadcasting:
-
-```ruby
-client = Eth::Client.create
-tx = Eth::Tx.new({
-  chain_id: client.chain_id,
-  nonce: client.get_nonce("0x...")
-  # ... additional transaction fields ...
-})
-signature = external.sign(tx.unsigned_hash, tx.chain_id)
-tx.sign_with(signature)
-client.eth_send_raw_transaction(tx.hex)
-```
-
 ## Documentation
 The documentation can be found at: https://q9f.github.io/eth.rb
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ and the
 [![Usage Wiki](https://img.shields.io/badge/usage-WIKI-blue)](https://github.com/q9f/eth.rb/wiki)
 for all the details and example snippets.
 
+### Signing transactions with external providers
+
+Keys can be kept with a remote signer or "key-as-a-service" provider. Build an
+unsigned transaction locally, obtain the signature from the external service and
+attach it before broadcasting:
+
+```ruby
+client = Eth::Client.create
+tx = Eth::Tx.new({
+  chain_id: client.chain_id,
+  nonce: client.get_nonce("0x...")
+  # ... additional transaction fields ...
+})
+signature = external.sign(tx.unsigned_hash, tx.chain_id)
+tx.sign_with(signature)
+client.eth_send_raw_transaction(tx.hex)
+```
+
 ## Documentation
 The documentation can be found at: https://q9f.github.io/eth.rb
 

--- a/lib/eth/tx/eip1559.rb
+++ b/lib/eth/tx/eip1559.rb
@@ -257,6 +257,31 @@ module Eth
         return hash
       end
 
+      # Signs the transaction with a provided signature blob.
+      #
+      # @param signature [String] the concatenated `r`, `s`, and `v` values.
+      # @return [String] a transaction hash.
+      # @raise [Signature::SignatureError] if transaction is already signed.
+      # @raise [Signature::SignatureError] if sender address does not match signer.
+      def sign_with(signature)
+        if Tx.signed? self
+          raise Signature::SignatureError, "Transaction is already signed!"
+        end
+
+        # ensure the sender address matches the signature
+        unless @sender.nil? or sender.empty?
+          public_key = Signature.recover(unsigned_hash, signature, @chain_id)
+          signer_address = Tx.sanitize_address Util.public_key_to_address(public_key).to_s
+          from_address = Tx.sanitize_address @sender
+          raise Signature::SignatureError, "Signer does not match sender" unless signer_address == from_address
+        end
+
+        r, s, v = Signature.dissect signature
+        recovery_id = Chain.to_recovery_id v.to_i(16), @chain_id
+        send :_set_signature, recovery_id, r, s
+        return hash
+      end
+
       # Encodes a raw transaction object, wraps it in an EIP-2718 envelope
       # with an EIP-1559 type prefix.
       #

--- a/lib/eth/tx/eip4844.rb
+++ b/lib/eth/tx/eip4844.rb
@@ -275,6 +275,31 @@ module Eth
         return hash
       end
 
+      # Signs the transaction with a provided signature blob.
+      #
+      # @param signature [String] the concatenated `r`, `s`, and `v` values.
+      # @return [String] a transaction hash.
+      # @raise [Signature::SignatureError] if transaction is already signed.
+      # @raise [Signature::SignatureError] if sender address does not match signer.
+      def sign_with(signature)
+        if Tx.signed? self
+          raise Signature::SignatureError, "Transaction is already signed!"
+        end
+
+        # ensure the sender address matches the signature
+        unless @sender.nil? or sender.empty?
+          public_key = Signature.recover(unsigned_hash, signature, @chain_id)
+          signer_address = Tx.sanitize_address Util.public_key_to_address(public_key).to_s
+          from_address = Tx.sanitize_address @sender
+          raise Signature::SignatureError, "Signer does not match sender" unless signer_address == from_address
+        end
+
+        r, s, v = Signature.dissect signature
+        recovery_id = Chain.to_recovery_id v.to_i(16), @chain_id
+        send :_set_signature, recovery_id, r, s
+        return hash
+      end
+
       # Encodes a raw transaction object, wraps it in an EIP-2718 envelope
       # with an EIP-4844 type prefix.
       #

--- a/lib/eth/tx/eip7702.rb
+++ b/lib/eth/tx/eip7702.rb
@@ -389,6 +389,31 @@ module Eth
         return hash
       end
 
+      # Signs the transaction with a provided signature blob.
+      #
+      # @param signature [String] the concatenated `r`, `s`, and `v` values.
+      # @return [String] a transaction hash.
+      # @raise [Signature::SignatureError] if transaction is already signed.
+      # @raise [Signature::SignatureError] if sender address does not match signer.
+      def sign_with(signature)
+        if Tx.signed? self
+          raise Signature::SignatureError, "Transaction is already signed!"
+        end
+
+        # ensure the sender address matches the signature
+        unless @sender.nil? or sender.empty?
+          public_key = Signature.recover(unsigned_hash, signature, @chain_id)
+          signer_address = Tx.sanitize_address Util.public_key_to_address(public_key).to_s
+          from_address = Tx.sanitize_address @sender
+          raise Signature::SignatureError, "Signer does not match sender" unless signer_address == from_address
+        end
+
+        r, s, v = Signature.dissect signature
+        recovery_id = Chain.to_recovery_id v.to_i(16), @chain_id
+        send :_set_signature, recovery_id, r, s
+        return hash
+      end
+
       # Encodes a raw transaction object, wraps it in an EIP-2718 envelope
       # with an EIP-7702 type prefix.
       #

--- a/lib/eth/tx/legacy.rb
+++ b/lib/eth/tx/legacy.rb
@@ -223,6 +223,30 @@ module Eth
         return hash
       end
 
+      # Signs the transaction with a provided signature blob.
+      #
+      # @param signature [String] the concatenated `r`, `s`, and `v` values.
+      # @return [String] a transaction hash.
+      # @raise [Signature::SignatureError] if transaction is already signed.
+      # @raise [Signature::SignatureError] if sender address does not match signer.
+      def sign_with(signature)
+        if Tx.signed? self
+          raise Signature::SignatureError, "Transaction is already signed!"
+        end
+
+        # ensure the sender address matches the signature
+        unless @sender.nil? or sender.empty?
+          public_key = Signature.recover(unsigned_hash, signature, @chain_id)
+          signer_address = Tx.sanitize_address Util.public_key_to_address(public_key).to_s
+          from_address = Tx.sanitize_address @sender
+          raise Signature::SignatureError, "Signer does not match sender" unless signer_address == from_address
+        end
+
+        r, s, v = Signature.dissect signature
+        send :_set_signature, v, r, s
+        return hash
+      end
+
       # Encodes a raw transaction object.
       #
       # @return [String] a raw, RLP-encoded legacy transaction.

--- a/spec/eth/tx/eip1559_spec.rb
+++ b/spec/eth/tx/eip1559_spec.rb
@@ -178,6 +178,18 @@ describe Tx::Eip1559 do
     end
   end
 
+  describe ".sign_with" do
+    it "signs with an external signature" do
+      signature = cow.sign(tx.unsigned_hash, tx.chain_id)
+      r, s, v = Signature.dissect(signature)
+      recovery_id = Chain.to_recovery_id v.to_i(16), tx.chain_id
+      tx.sign_with(signature)
+      expect(tx.signature_y_parity).to eq recovery_id
+      expect(tx.signature_r).to eq r
+      expect(tx.signature_s).to eq s
+    end
+  end
+
   describe ".encoded" do
     it "encodes the default transaction" do
       expect { tx.encoded }.to raise_error StandardError, "Transaction is not signed!"

--- a/spec/eth/tx/eip2930_spec.rb
+++ b/spec/eth/tx/eip2930_spec.rb
@@ -173,6 +173,18 @@ describe Tx::Eip2930 do
     end
   end
 
+  describe ".sign_with" do
+    it "signs with an external signature" do
+      signature = cow.sign(tx.unsigned_hash, tx.chain_id)
+      r, s, v = Signature.dissect(signature)
+      recovery_id = Chain.to_recovery_id v.to_i(16), tx.chain_id
+      tx.sign_with(signature)
+      expect(tx.signature_y_parity).to eq recovery_id
+      expect(tx.signature_r).to eq r
+      expect(tx.signature_s).to eq s
+    end
+  end
+
   describe ".encoded" do
     it "encodes the default transaction" do
       expect { tx.encoded }.to raise_error StandardError, "Transaction is not signed!"

--- a/spec/eth/tx/eip4844_spec.rb
+++ b/spec/eth/tx/eip4844_spec.rb
@@ -34,6 +34,18 @@ describe Tx::Eip4844 do
     end
   end
 
+  describe ".sign_with" do
+    it "signs with an external signature" do
+      signature = cow.sign(tx.unsigned_hash, tx.chain_id)
+      r, s, v = Signature.dissect(signature)
+      recovery_id = Chain.to_recovery_id v.to_i(16), tx.chain_id
+      tx.sign_with(signature)
+      expect(tx.signature_y_parity).to eq recovery_id
+      expect(tx.signature_r).to eq r
+      expect(tx.signature_s).to eq s
+    end
+  end
+
   describe ".hex" do
     it "hexes the default transaction" do
       tx.sign(cow)

--- a/spec/eth/tx/eip7702_spec.rb
+++ b/spec/eth/tx/eip7702_spec.rb
@@ -272,6 +272,18 @@ describe Tx::Eip7702 do
     end
   end
 
+  describe ".sign_with" do
+    it "signs with an external signature" do
+      signature = cow.sign(tx.unsigned_hash, tx.chain_id)
+      r, s, v = Signature.dissect(signature)
+      recovery_id = Chain.to_recovery_id v.to_i(16), tx.chain_id
+      tx.sign_with(signature)
+      expect(tx.signature_y_parity).to eq recovery_id
+      expect(tx.signature_r).to eq r
+      expect(tx.signature_s).to eq s
+    end
+  end
+
   describe ".encoded" do
     it "encodes the default transaction" do
       expect { tx.encoded }.to raise_error StandardError, "Transaction is not signed!"

--- a/spec/eth/tx/legacy_spec.rb
+++ b/spec/eth/tx/legacy_spec.rb
@@ -197,6 +197,17 @@ describe Tx::Legacy do
     end
   end
 
+  describe ".sign_with" do
+    it "signs with an external signature" do
+      signature = cow.sign(tx.unsigned_hash, tx.chain_id)
+      r, s, v = Signature.dissect(signature)
+      tx.sign_with(signature)
+      expect(tx.signature_v).to eq v
+      expect(tx.signature_r).to eq r
+      expect(tx.signature_s).to eq s
+    end
+  end
+
   describe ".encoded" do
     it "encodes the default transaction" do
       expect { tx.encoded }.to raise_error StandardError, "Transaction is not signed!"


### PR DESCRIPTION
- support applying externally produced signatures to transactions
- document how to sign via remote key providers
- test external signature workflow for EIP-1559 and legacy transactions

fix #316 