### PR TITLE
Move error decoding to contract module

### DIFF
--- a/lib/eth/contract.rb
+++ b/lib/eth/contract.rb
@@ -167,6 +167,7 @@ module Eth
         def_delegator :parent, :functions
         def_delegator :parent, :function
         def_delegator :parent, :error
+        def_delegator :parent, :decode_error
         def_delegator :parent, :constructor_inputs
         define_method :parent do
           parent

--- a/spec/eth/contract/error_spec.rb
+++ b/spec/eth/contract/error_spec.rb
@@ -30,4 +30,12 @@ describe Contract do
       expect { client.call(contract, "foo") }.to raise_error(Client::ContractExecutionError, "execution reverted: Unauthorized(0x0000000000000000000000000000000000000000)")
     end
   end
+
+  describe "#decode_error" do
+    let(:rpc_error) { Client::RpcError.new("execution reverted", error_data) }
+
+    it "returns a readable message" do
+      expect(contract.decode_error(rpc_error)).to eq("execution reverted: Unauthorized(0x0000000000000000000000000000000000000000)")
+    end
+  end
 end

--- a/spec/eth/contract/error_spec.rb
+++ b/spec/eth/contract/error_spec.rb
@@ -1,29 +1,29 @@
 require "spec_helper"
 
 describe Contract do
+  let(:abi) do
+    [
+      { "type" => "function", "name" => "foo", "inputs" => [], "outputs" => [] },
+      {
+        "type" => "error",
+        "name" => "Unauthorized",
+        "inputs" => [{ "name" => "addr", "type" => "address" }],
+      },
+    ]
+  end
+
+  let(:contract) do
+    Contract.from_abi(abi: abi, address: Address::ZERO, name: "Foo")
+  end
+
+  let(:error_data) do
+    sig = contract.errors.first.signature
+    encoded = Util.bin_to_hex(Abi.encode(["address"], [Address::ZERO]))
+    sig + encoded
+  end
+
   describe "#call with custom error" do
     let(:client) { Client.new(nil) }
-
-    let(:abi) do
-      [
-        { "type" => "function", "name" => "foo", "inputs" => [], "outputs" => [] },
-        {
-          "type" => "error",
-          "name" => "Unauthorized",
-          "inputs" => [{ "name" => "addr", "type" => "address" }],
-        },
-      ]
-    end
-
-    let(:contract) do
-      Contract.from_abi(abi: abi, address: Address::ZERO, name: "Foo")
-    end
-
-    let(:error_data) do
-      sig = contract.errors.first.signature
-      encoded = Util.bin_to_hex(Abi.encode(["address"], [Address::ZERO]))
-      sig + encoded
-    end
 
     it "decodes custom error data" do
       allow(client).to receive(:eth_call).and_raise(Client::RpcError.new("execution reverted", error_data))


### PR DESCRIPTION
- move error decoding logic into `Eth::Contract#decode_error`
- delegate error handling in `Eth::Client` to the contract
- add spec for `Contract#decode_error`
