### PR TITLE
Enforce minimal RLP integer decoding

### DIFF
--- a/lib/eth/tx/eip1559.rb
+++ b/lib/eth/tx/eip1559.rb
@@ -148,13 +148,13 @@ module Eth
         raise ParameterError, "Transaction missing fields!" if tx.size < 9
 
         # populate the 9 payload fields
-        chain_id = Util.deserialize_big_endian_to_int tx[0]
-        nonce = Util.deserialize_big_endian_to_int tx[1]
-        priority_fee = Util.deserialize_big_endian_to_int tx[2]
-        max_gas_fee = Util.deserialize_big_endian_to_int tx[3]
-        gas_limit = Util.deserialize_big_endian_to_int tx[4]
+        chain_id = Util.deserialize_rlp_int tx[0]
+        nonce = Util.deserialize_rlp_int tx[1]
+        priority_fee = Util.deserialize_rlp_int tx[2]
+        max_gas_fee = Util.deserialize_rlp_int tx[3]
+        gas_limit = Util.deserialize_rlp_int tx[4]
         to = Util.bin_to_hex tx[5]
-        value = Util.deserialize_big_endian_to_int tx[6]
+        value = Util.deserialize_rlp_int tx[6]
         data = tx[7]
         access_list = tx[8]
 

--- a/lib/eth/tx/eip2930.rb
+++ b/lib/eth/tx/eip2930.rb
@@ -145,12 +145,12 @@ module Eth
         raise ParameterError, "Transaction missing fields!" if tx.size < 8
 
         # populate the 8 payload fields
-        chain_id = Util.deserialize_big_endian_to_int tx[0]
-        nonce = Util.deserialize_big_endian_to_int tx[1]
-        gas_price = Util.deserialize_big_endian_to_int tx[2]
-        gas_limit = Util.deserialize_big_endian_to_int tx[3]
+        chain_id = Util.deserialize_rlp_int tx[0]
+        nonce = Util.deserialize_rlp_int tx[1]
+        gas_price = Util.deserialize_rlp_int tx[2]
+        gas_limit = Util.deserialize_rlp_int tx[3]
         to = Util.bin_to_hex tx[4]
-        value = Util.deserialize_big_endian_to_int tx[5]
+        value = Util.deserialize_rlp_int tx[5]
         data = tx[6]
         access_list = tx[7]
 

--- a/lib/eth/tx/eip4844.rb
+++ b/lib/eth/tx/eip4844.rb
@@ -160,16 +160,16 @@ module Eth
         raise ParameterError, "Transaction missing fields!" if tx.size < 11
 
         # populate the 11 payload fields
-        chain_id = Util.deserialize_big_endian_to_int tx[0]
-        nonce = Util.deserialize_big_endian_to_int tx[1]
-        priority_fee = Util.deserialize_big_endian_to_int tx[2]
-        max_gas_fee = Util.deserialize_big_endian_to_int tx[3]
-        gas_limit = Util.deserialize_big_endian_to_int tx[4]
+        chain_id = Util.deserialize_rlp_int tx[0]
+        nonce = Util.deserialize_rlp_int tx[1]
+        priority_fee = Util.deserialize_rlp_int tx[2]
+        max_gas_fee = Util.deserialize_rlp_int tx[3]
+        gas_limit = Util.deserialize_rlp_int tx[4]
         to = Util.bin_to_hex tx[5]
-        value = Util.deserialize_big_endian_to_int tx[6]
+        value = Util.deserialize_rlp_int tx[6]
         data = tx[7]
         access_list = tx[8]
-        max_fee_per_blob_gas = Util.deserialize_big_endian_to_int tx[9]
+        max_fee_per_blob_gas = Util.deserialize_rlp_int tx[9]
         blob_versioned_hashes = tx[10]
 
         # populate class attributes

--- a/lib/eth/tx/eip7702.rb
+++ b/lib/eth/tx/eip7702.rb
@@ -269,13 +269,13 @@ module Eth
         raise ParameterError, "Transaction missing fields!" if tx.size < 10
 
         # populate the 10 payload fields
-        chain_id = Util.deserialize_big_endian_to_int tx[0]
-        nonce = Util.deserialize_big_endian_to_int tx[1]
-        priority_fee = Util.deserialize_big_endian_to_int tx[2]
-        max_gas_fee = Util.deserialize_big_endian_to_int tx[3]
-        gas_limit = Util.deserialize_big_endian_to_int tx[4]
+        chain_id = Util.deserialize_rlp_int tx[0]
+        nonce = Util.deserialize_rlp_int tx[1]
+        priority_fee = Util.deserialize_rlp_int tx[2]
+        max_gas_fee = Util.deserialize_rlp_int tx[3]
+        gas_limit = Util.deserialize_rlp_int tx[4]
         to = Util.bin_to_hex tx[5]
-        value = Util.deserialize_big_endian_to_int tx[6]
+        value = Util.deserialize_rlp_int tx[6]
         data = tx[7]
         access_list = tx[8]
         authorization_list = tx[9]
@@ -474,9 +474,9 @@ module Eth
 
       def deserialize_authorizations(authorization_list)
         authorization_list.map do |authorization_tuple|
-          chain_id = Util.deserialize_big_endian_to_int authorization_tuple[0]
+          chain_id = Util.deserialize_rlp_int authorization_tuple[0]
           address = Util.bin_to_hex authorization_tuple[1]
-          nonce = Util.deserialize_big_endian_to_int authorization_tuple[2]
+          nonce = Util.deserialize_rlp_int authorization_tuple[2]
           recovery_id = Util.bin_to_hex(authorization_tuple[3]).to_i(16)
           r = Util.bin_to_hex authorization_tuple[4]
           s = Util.bin_to_hex authorization_tuple[5]

--- a/lib/eth/tx/legacy.rb
+++ b/lib/eth/tx/legacy.rb
@@ -128,18 +128,18 @@ module Eth
         raise ParameterError, "Transaction missing fields!" if tx.size < 9
 
         # populate the 9 fields
-        nonce = Util.deserialize_big_endian_to_int tx[0]
-        gas_price = Util.deserialize_big_endian_to_int tx[1]
-        gas_limit = Util.deserialize_big_endian_to_int tx[2]
+        nonce = Util.deserialize_rlp_int tx[0]
+        gas_price = Util.deserialize_rlp_int tx[1]
+        gas_limit = Util.deserialize_rlp_int tx[2]
         to = Util.bin_to_hex tx[3]
-        value = Util.deserialize_big_endian_to_int tx[4]
+        value = Util.deserialize_rlp_int tx[4]
         data = tx[5]
         v = Util.bin_to_hex tx[6]
         r = Util.bin_to_hex tx[7]
         s = Util.bin_to_hex tx[8]
 
         # try to recover the chain id from v
-        chain_id = Chain.to_chain_id Util.deserialize_big_endian_to_int tx[6]
+        chain_id = Chain.to_chain_id Util.deserialize_rlp_int tx[6]
 
         # populate class attributes
         @signer_nonce = nonce.to_i

--- a/lib/eth/util.rb
+++ b/lib/eth/util.rb
@@ -145,6 +145,15 @@ module Eth
       Rlp::Sedes.big_endian_int.deserialize str.sub(/\A(\x00)+/, "")
     end
 
+    # Deserializes an RLP integer, enforcing minimal encoding.
+    #
+    # @param str [String] serialized big endian integer string.
+    # @return [Integer] a deserialized unsigned integer.
+    # @raise [Rlp::DeserializationError] if encoding is not minimal.
+    def deserialize_rlp_int(str)
+      Rlp::Sedes.big_endian_int.deserialize str
+    end
+
     # Converts a big endian to an interger.
     #
     # @param str [String] big endian to be converted.

--- a/spec/eth/tx/eip2930_spec.rb
+++ b/spec/eth/tx/eip2930_spec.rb
@@ -65,6 +65,39 @@ describe Tx::Eip2930 do
       expect(type01.hex).to eq duplicated.hex
       expect(type01.hash).to eq duplicated.hash
     end
+
+    it "raises on non-minimal integer encoding" do
+      fields = [
+        Util.serialize_int_to_big_endian(1),
+        "\x00\x01",
+        Util.serialize_int_to_big_endian(1),
+        Util.serialize_int_to_big_endian(1),
+        "",
+        Util.serialize_int_to_big_endian(1),
+        "",
+        [],
+      ]
+      encoded = Rlp.encode(fields)
+      hex = "0x01#{Util.bin_to_hex(encoded)}"
+      expect { Tx::Eip2930.decode(hex) }.to raise_error Rlp::DeserializationError
+    end
+
+    it "round-trips valid integer encoding" do
+      fields = [
+        Util.serialize_int_to_big_endian(1),
+        Util.serialize_int_to_big_endian(1),
+        Util.serialize_int_to_big_endian(1),
+        Util.serialize_int_to_big_endian(1),
+        "",
+        Util.serialize_int_to_big_endian(1),
+        "",
+        [],
+      ]
+      encoded = Rlp.encode(fields)
+      hex = "0x01#{Util.bin_to_hex(encoded)}"
+      tx = Tx::Eip2930.decode(hex)
+      expect(tx.signer_nonce).to eq 1
+    end
   end
 
   describe ".initialize" do

--- a/spec/eth/tx/eip4844_spec.rb
+++ b/spec/eth/tx/eip4844_spec.rb
@@ -48,5 +48,44 @@ describe Tx::Eip4844 do
       expect(blob_tx).to be_instance_of Tx::Eip4844
       expect(blob_tx.hex).to eq tx.hex
     end
+
+    it "raises on non-minimal integer encoding" do
+      fields = [
+        Util.serialize_int_to_big_endian(1),
+        "\x00\x01",
+        Util.serialize_int_to_big_endian(1),
+        Util.serialize_int_to_big_endian(1),
+        Util.serialize_int_to_big_endian(1),
+        "",
+        Util.serialize_int_to_big_endian(1),
+        "",
+        [],
+        Util.serialize_int_to_big_endian(1),
+        [],
+      ]
+      encoded = Rlp.encode(fields)
+      hex = "0x03#{Util.bin_to_hex(encoded)}"
+      expect { Tx::Eip4844.decode(hex) }.to raise_error Rlp::DeserializationError
+    end
+
+    it "round-trips valid integer encoding" do
+      fields = [
+        Util.serialize_int_to_big_endian(1),
+        Util.serialize_int_to_big_endian(1),
+        Util.serialize_int_to_big_endian(1),
+        Util.serialize_int_to_big_endian(1),
+        Util.serialize_int_to_big_endian(1),
+        "",
+        Util.serialize_int_to_big_endian(1),
+        "",
+        [],
+        Util.serialize_int_to_big_endian(1),
+        [],
+      ]
+      encoded = Rlp.encode(fields)
+      hex = "0x03#{Util.bin_to_hex(encoded)}"
+      tx = Tx::Eip4844.decode(hex)
+      expect(tx.signer_nonce).to eq 1
+    end
   end
 end

--- a/spec/eth/util_spec.rb
+++ b/spec/eth/util_spec.rb
@@ -193,6 +193,20 @@ describe Util do
     end
   end
 
+  describe ".deserialize_rlp_int" do
+    it "raises on non-minimal encodings" do
+      expect { Util.deserialize_rlp_int "\x00" }.to raise_error Rlp::DeserializationError
+      expect { Util.deserialize_rlp_int "\x00\x01" }.to raise_error Rlp::DeserializationError
+    end
+
+    it "round-trips valid integers" do
+      [0, 1, 256].each do |n|
+        encoded = Util.serialize_int_to_big_endian n
+        expect(Util.deserialize_rlp_int encoded).to eq n
+      end
+    end
+  end
+
   describe ".ceil32 .lpad .zpad{,_int,_hex}" do
     it "can ceil to the next multiple of 32 bytes" do
       expect(Util.ceil32 0).to eq 0


### PR DESCRIPTION
## Summary
- add `deserialize_rlp_int` helper to delegate to `Rlp::Sedes.big_endian_int.deserialize`
- require minimal integer encoding across all transaction decoders
- test for RLP integer minimality and round-trip safety

## Testing
- `bundle _2.7.1_ exec rspec spec/eth/util_spec.rb spec/eth/tx/legacy_spec.rb spec/eth/tx/eip1559_spec.rb spec/eth/tx/eip2930_spec.rb spec/eth/tx/eip4844_spec.rb spec/eth/tx/eip7702_spec.rb`

------
https://chatgpt.com/codex/tasks/task_e_689067d70bb4832b9e1a0ade2949627e