### PR TITLE
test: decode eip4844 blobs

### DIFF
--- a/spec/eth/tx/eip4844_spec.rb
+++ b/spec/eth/tx/eip4844_spec.rb
@@ -154,9 +154,9 @@ describe Tx::Eip4844 do
       expect(blob_tx).to be_instance_of Tx::Eip4844
       hashes = blob_tx.blob_versioned_hashes.map { |b| Util.bin_to_hex b }
       expect(hashes).to eq [
-          "0183be5e67ea6eb79f14071b13f96e51522f1b74566b95a015dd2f7deb9efdab",
-          "01b7e9368622cfd553884b59fbce02cee983a43c9d66bc26eca20973570e86e2",
-        ]
+                             "0183be5e67ea6eb79f14071b13f96e51522f1b74566b95a015dd2f7deb9efdab",
+                             "01b7e9368622cfd553884b59fbce02cee983a43c9d66bc26eca20973570e86e2",
+                           ]
     end
 
     it "raises on non-minimal integer encoding" do


### PR DESCRIPTION
## Summary
- add spec to parse EIP-4844 raw transaction with blob hashes

ref #322 

ref https://sepolia.etherscan.io/tx/0xc177b7159aba6372bbf296cd7711793324abea797289cf75e72fbd514bd6ce31#blobs