### PR TITLE
Implement EIP712 array encoding

### DIFF
--- a/lib/eth/eip712.rb
+++ b/lib/eth/eip712.rb
@@ -47,7 +47,12 @@ module Eth
 
         # recursively look for further nested dependencies
         types[primary_type.to_sym].each do |t|
-          dependency = type_dependencies t[:type], types, result
+          nested_type = t[:type]
+          # unpack arrays to their inner types to resolve dependencies
+          if nested_type.end_with?(']')
+            nested_type = nested_type.partition('[').first
+          end
+          dependency = type_dependencies nested_type, types, result
         end
         return result
       end
@@ -113,19 +118,12 @@ module Eth
       types[primary_type.to_sym].each do |field|
         value = data[field[:name].to_sym]
         type = field[:type]
-        if type == "string"
+        if type.end_with?(']')
+          encoded_types.push type
+          encoded_values.push encode_array(type, value, types)
+        elsif type == "string" || type == "bytes" || !types[type.to_sym].nil?
           encoded_types.push "bytes32"
-          encoded_values.push Util.keccak256 value
-        elsif type == "bytes"
-          encoded_types.push "bytes32"
-          value = Util.hex_to_bin value
-          encoded_values.push Util.keccak256 value
-        elsif !types[type.to_sym].nil?
-          encoded_types.push "bytes32"
-          value = encode_data type, value, types
-          encoded_values.push Util.keccak256 value
-        elsif type.end_with? "]"
-          raise NotImplementedError, "Arrays currently unimplemented for EIP-712."
+          encoded_values.push encode_value(type, value, types)
         else
           encoded_types.push type
           encoded_values.push value
@@ -134,6 +132,43 @@ module Eth
 
       # all data is abi-encoded
       return Abi.encode encoded_types, encoded_values
+    end
+
+    # Encodes a single value according to its type following EIP-712 rules.
+    # Returns a 32-byte binary string.
+    def encode_value(type, value, types)
+      if type == "string"
+        return Util.keccak256 value
+      elsif type == "bytes"
+        value = Util.hex_to_bin value
+        return Util.keccak256 value
+      elsif !types[type.to_sym].nil?
+        nested = encode_data type, value, types
+        return Util.keccak256 nested
+      else
+        # encode basic types via ABI to get 32-byte representation
+        return Abi.encode([type], [value])
+      end
+    end
+
+    # Prepares array values by encoding each element according to its
+    # base type. Returns an array compatible with Abi.encode.
+    def encode_array(type, value, types)
+      inner_type = type.slice(0, type.rindex('['))
+      return [] if value.nil?
+      value.map do |v|
+        if inner_type.end_with?(']')
+          encode_array inner_type, v, types
+        elsif inner_type == "string"
+          Util.keccak256 v
+        elsif inner_type == "bytes"
+          Util.keccak256 Util.hex_to_bin(v)
+        elsif !types[inner_type.to_sym].nil?
+          Util.keccak256 encode_data(inner_type, v, types)
+        else
+          v
+        end
+      end
     end
 
     # Recursively ABI-encodes and hashes all data and types.

--- a/spec/eth/eip712_spec.rb
+++ b/spec/eth/eip712_spec.rb
@@ -128,6 +128,40 @@ describe Eip712 do
     end
   end
 
+  describe ".encode_value" do
+    it "abi-encodes primitive values" do
+      expect(Eip712.encode_value("uint256", 1, {})).to eq Abi.encode(["uint256"], [1])
+    end
+  end
+
+  describe ".encode_array" do
+    it "hashes string array items" do
+      expect(Eip712.encode_array("string[]", ["foo", "bar"], {})).to eq [Util.keccak256("foo"), Util.keccak256("bar")]
+    end
+
+    it "hashes bytes array items" do
+      arr = ["0x1234", "0xabcd"]
+      expected = arr.map { |v| Util.keccak256(Util.hex_to_bin(v)) }
+      expect(Eip712.encode_array("bytes[]", arr, {})).to eq expected
+    end
+
+    it "hashes struct array items" do
+      types = { Person: person }
+      people = [
+        { name: "Cow", wallet: Address.new("0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826") },
+        { name: "Bob", wallet: Address.new("0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB") },
+      ]
+      expected = people.map { |p| Util.keccak256(Eip712.encode_data("Person", p, types)) }
+      expect(Eip712.encode_array("Person[]", people, types)).to eq expected
+    end
+
+    it "recursively encodes nested arrays" do
+      nested = [["foo"], ["bar"]]
+      expected = nested.map { |inner| inner.map { |v| Util.keccak256(v) } }
+      expect(Eip712.encode_array("string[][]", nested, {})).to eq expected
+    end
+  end
+
   context "eip 712 arrays" do
     subject(:domain) {
       [
@@ -192,7 +226,6 @@ describe Eip712 do
       expect(Eip712.encode_type "SellOrders", data[:types]).to eq "SellOrders(uint256[] id,uint256[] tokenId,uint256[] price,uint256[] proto,uint256[] purity,address seller)"
 
       expect(Util.bin_to_hex(Eip712.encode_data("EIP712Domain", domain_data, data[:types]))).to eq "d87cd6ef79d4e2b95e15ce8abf732db51ec771f1ca2edccf22a46c729ac56472d6f028ca0e8edb4a8c9757ca4fdccab25fa1e0317da1188108f7d2dee14902fbc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc60000000000000000000000000000000000000000000000000000000000000003000000000000000000000000cccccccccccccccccccccccccccccccccccccccca222082684812afae4e093416fff16bc218b569abe4db590b6a058e1f2c1cd3e"
-      pending("https://github.com/q9f/eth.rb/issues/127")
       expect(Util.bin_to_hex(Eip712.encode_data("SellOrders", message, data[:types]))).to eq "58682cd513b67511a4ef89156104cf2bc7835c7289308bb112fdafe49897324200000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000001a000000000000000000000000000000000000000000000000000000000000001e0000000000000000000000000cd2a3d9f938e13cd947ec05abc7fe734df8dd8260000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001"
     end
   end


### PR DESCRIPTION
## Summary
- support arrays in EIP-712 type dependency detection and encoding
- enable SellOrders typed-data test by removing pending flag
- prevent catastrophic regex backtracking and expand encode_array coverage
- eliminate polynomial regex in EIP-712 array and dependency parsing

## Testing
- `bundle exec rspec spec/eth/eip712_spec.rb`


------
https://chatgpt.com/codex/tasks/task_e_689321638a1c832bb0d91636fa2c2416