### PR TITLE
Increase blob throughput limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ What you get:
 - [x] EIP-2028 Call-data intrinsic gas cost estimates (plus access lists)
 - [x] EIP-2718 Ethereum Transaction Envelopes (and types)
 - [x] EIP-2930 Ethereum Type-1 Transactions (with access lists)
-- [x] EIP-4844 Ethereum Type-3 Transactions (with shard blobs)
+- [x] EIP-4844 Ethereum Type-3 Transactions (with shard blobs, up to 9 blobs per block)
 - [x] EIP-7702 Ethereum Type-4 Transactions (with authorization lists)
 - [x] ABI-Encoder and Decoder (including type parser)
 - [x] Packed ABI-Encoder for Solidity smart contracts

--- a/lib/eth/tx.rb
+++ b/lib/eth/tx.rb
@@ -286,13 +286,16 @@ module Eth
     #
     # @param fields [Hash] the transaction fields.
     # @return [Hash] the validated transaction fields.
-    # @raise [ParameterError] if max blob fee or blob hashes are invalid.
+    # @raise [ParameterError] if max blob fee or blob hashes are invalid or exceed limits.
     def validate_eip4844_params(fields)
       if fields[:max_fee_per_blob_gas].nil? or fields[:max_fee_per_blob_gas] < 0
         raise ParameterError, "Invalid max blob fee #{fields[:max_fee_per_blob_gas]}!"
       end
       if fields[:blob_versioned_hashes].nil? or !fields[:blob_versioned_hashes].is_a? Array or fields[:blob_versioned_hashes].empty?
         raise ParameterError, "Invalid blob versioned hashes #{fields[:blob_versioned_hashes]}!"
+      end
+      if fields[:blob_versioned_hashes].length > Eip4844::MAX_BLOBS_PER_BLOCK
+        raise ParameterError, "Too many blob versioned hashes #{fields[:blob_versioned_hashes].length}!"
       end
       if fields[:to].nil? or fields[:to].empty?
         raise ParameterError, "Invalid destination address #{fields[:to]}!"

--- a/lib/eth/tx/eip4844.rb
+++ b/lib/eth/tx/eip4844.rb
@@ -23,6 +23,18 @@ module Eth
     # Ref: https://eips.ethereum.org/EIPS/eip-4844
     class Eip4844
 
+      # The blob gas consumed by a single blob.
+      GAS_PER_BLOB = (2**17).freeze
+
+      # The target blob gas per block as per EIP-7691.
+      TARGET_BLOB_GAS_PER_BLOCK = 786_432.freeze
+
+      # The maximum blob gas allowed in a block as per EIP-7691.
+      MAX_BLOB_GAS_PER_BLOCK = 1_179_648.freeze
+
+      # The maximum number of blobs permitted in a single block.
+      MAX_BLOBS_PER_BLOCK = (MAX_BLOB_GAS_PER_BLOCK / GAS_PER_BLOB).freeze
+
       # The EIP-155 Chain ID.
       # Ref: https://eips.ethereum.org/EIPS/eip-155
       attr_reader :chain_id
@@ -89,7 +101,7 @@ module Eth
       # @option params [String] :data the transaction data payload.
       # @option params [Array] :access_list an optional access list.
       # @option params [Integer] :max_fee_per_blob_gas the max blob fee per gas.
-      # @option params [Array] :blob_versioned_hashes the blob versioned hashes.
+      # @option params [Array] :blob_versioned_hashes the blob versioned hashes (max 9).
       # @raise [ParameterError] if gas limit is too low.
       def initialize(params)
         fields = { recovery_id: nil, r: 0, s: 0 }.merge params

--- a/spec/eth/tx/eip4844_spec.rb
+++ b/spec/eth/tx/eip4844_spec.rb
@@ -55,6 +55,30 @@ describe Tx::Eip4844 do
           blob_versioned_hashes: blob_hashes,
         })
       }.to raise_error Tx::ParameterError, /Invalid destination address/
+
+      expect {
+        Tx::Eip4844.new({
+          nonce: 0,
+          priority_fee: 0,
+          max_gas_fee: Unit::WEI,
+          gas_limit: Tx::DEFAULT_GAS_LIMIT,
+          to: "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+          max_fee_per_blob_gas: Unit::WEI,
+          blob_versioned_hashes: Array.new(Tx::Eip4844::MAX_BLOBS_PER_BLOCK, blob_hashes.first),
+        })
+      }.not_to raise_error
+
+      expect {
+        Tx::Eip4844.new({
+          nonce: 0,
+          priority_fee: 0,
+          max_gas_fee: Unit::WEI,
+          gas_limit: Tx::DEFAULT_GAS_LIMIT,
+          to: "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+          max_fee_per_blob_gas: Unit::WEI,
+          blob_versioned_hashes: Array.new(Tx::Eip4844::MAX_BLOBS_PER_BLOCK + 1, blob_hashes.first),
+        })
+      }.to raise_error Tx::ParameterError, /Too many blob versioned hashes/
     end
   end
 


### PR DESCRIPTION
## Summary
- raise EIP-4844 blob throughput constants to match new per-block targets
- validate blob versioned hash count against updated max and expand tests
- document new blob limits in README

## Testing
- `bundle _2.7.1_ exec rspec spec/eth/tx/eip4844_spec.rb`


------
https://chatgpt.com/codex/tasks/task_e_689357224cbc832bb3afba13bd389085