### PR TITLE
Add validator withdrawal request helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ and the
 [![Usage Wiki](https://img.shields.io/badge/usage-WIKI-blue)](https://github.com/q9f/eth.rb/wiki)
 for all the details and example snippets.
 
+### Validator withdrawals
+
+Networks implementing [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002)
+allow validators to trigger withdrawals through a predeploy contract. The
+current fee can be queried and a request submitted as follows:
+
+```ruby
+client = Eth::Client.create "/tmp/geth.ipc"
+fee = client.withdrawal_request_fee
+pubkey = "0x" + ("11" * 48)
+tx = client.request_validator_withdrawal(pubkey, 1)
+client.wait_for_tx tx
+```
+
 ## Documentation
 The documentation can be found at: https://q9f.github.io/eth.rb
 

--- a/spec/eth/withdrawal_spec.rb
+++ b/spec/eth/withdrawal_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe Client do
+  subject(:geth) { Client.create "/tmp/geth.ipc" }
+
+  describe ".request_validator_withdrawal" do
+    it "requests a validator withdrawal" do
+      fee = geth.withdrawal_request_fee
+      expect(fee).to be >= 0
+      pubkey = "0x" + ("11" * 48)
+      tx_hash = geth.request_validator_withdrawal(pubkey, 1)
+      expect(tx_hash).to start_with "0x"
+      geth.wait_for_tx tx_hash
+      receipt = geth.eth_get_transaction_receipt tx_hash
+      expect(receipt["result"]).to be
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add RPC helper to request validator withdrawals per EIP-7002
- document validator withdrawal usage in README
- test validator withdrawal helper

## Testing
- `bundle _2.7.1_ install`
- `bundle _2.7.1_ exec rspec spec/eth/withdrawal_spec.rb` *(fails: No such file or directory - connect(2) for /tmp/geth.ipc)*


------
https://chatgpt.com/codex/tasks/task_e_689357337f74832b936f3da6cea5c6f4