### PR TITLE
Add tuple array ABI support

### DIFF
--- a/lib/eth/abi/decoder.rb
+++ b/lib/eth/abi/decoder.rb
@@ -62,10 +62,10 @@ module Eth
             if c.dynamic?
               pointer = Util.deserialize_big_endian_to_int arg[offset, 32]
               next_offset = if i + 1 < type.components.size
-                              Util.deserialize_big_endian_to_int arg[offset + 32, 32]
-                            else
-                              arg.size
-                            end
+                  Util.deserialize_big_endian_to_int arg[offset + 32, 32]
+                else
+                  arg.size
+                end
               raise DecodingError, "Offset out of bounds" if pointer > arg.size || next_offset > arg.size || next_offset < pointer
               result << type(c, arg[pointer, next_offset - pointer])
               offset += 32

--- a/lib/eth/abi/decoder.rb
+++ b/lib/eth/abi/decoder.rb
@@ -54,24 +54,29 @@ module Eth
               type(Type.parse(type.base_type), arg[pointer + 32, Util.ceil32(data_l) + 32])
             end
           end
-        elsif type.base_type == "tuple"
+        elsif type.base_type == "tuple" && type.dimensions.empty?
           offset = 0
-          data = {}
+          result = []
           raise DecodingError, "Cannot decode tuples without known components" if type.components.nil?
-          type.components.each do |c|
+          type.components.each_with_index do |c, i|
             if c.dynamic?
-              pointer = Util.deserialize_big_endian_to_int arg[offset, 32] # Pointer to the size of the array's element
-              data_len = Util.deserialize_big_endian_to_int arg[pointer, 32] # length of the element
-
-              data[c.name] = type(c, arg[pointer, Util.ceil32(data_len) + 32])
+              pointer = Util.deserialize_big_endian_to_int arg[offset, 32]
+              next_offset = if i + 1 < type.components.size
+                              Util.deserialize_big_endian_to_int arg[offset + 32, 32]
+                            else
+                              arg.size
+                            end
+              raise DecodingError, "Offset out of bounds" if pointer > arg.size || next_offset > arg.size || next_offset < pointer
+              result << type(c, arg[pointer, next_offset - pointer])
               offset += 32
             else
               size = c.size
-              data[c.name] = type(c, arg[offset, size])
+              raise DecodingError, "Offset out of bounds" if offset + size > arg.size
+              result << type(c, arg[offset, size])
               offset += size
             end
           end
-          data
+          result
         elsif type.dynamic?
           l = Util.deserialize_big_endian_to_int arg[0, 32]
           nested_sub = type.nested_sub
@@ -93,8 +98,21 @@ module Eth
           l = type.dimensions.first
           nested_sub = type.nested_sub
 
-          # decoded static-size arrays
-          (0...l).map { |i| type(nested_sub, arg[nested_sub.size * i, nested_sub.size]) }
+          if nested_sub.dynamic?
+            raise DecodingError, "Wrong data size for static array" unless arg.size >= 32 * l
+            offsets = (0...l).map do |i|
+              off = Util.deserialize_big_endian_to_int arg[32 * i, 32]
+              raise DecodingError, "Offset out of bounds" if off < 32 * l || off > arg.size - 32
+              off
+            end
+            offsets.each_with_index.map do |off, i|
+              size = (i + 1 < offsets.length ? offsets[i + 1] : arg.size) - off
+              type(nested_sub, arg[off, size])
+            end
+          else
+            # decoded static-size arrays with static sub-types
+            (0...l).map { |i| type(nested_sub, arg[nested_sub.size * i, nested_sub.size]) }
+          end
         else
 
           # decoded primitive types
@@ -119,7 +137,9 @@ module Eth
             size = Util.deserialize_big_endian_to_int data[0, 32]
 
             # decoded dynamic-sized array
-            data[32..-1][0, size]
+            decoded = data[32..-1][0, size]
+            decoded.force_encoding(Encoding::UTF_8)
+            decoded
           else
 
             # decoded static-sized array

--- a/spec/eth/abi/event_spec.rb
+++ b/spec/eth/abi/event_spec.rb
@@ -188,20 +188,20 @@ describe Abi::Event do
 
       expect(args[0]).to eq "\xF6T\xC1~\xA8\x91\b\xD7\x18>\xAF1\xC7b\xFE\f\x12]Gj\xA8\x13\t8\xD8\xA1\x89S\a\xB7\xDBZ"
       expect(args[1]).to eq "\xFC*\a\xBA\xE9\xB7]Z\x81z\xA5\xFFu-&=!2\x86\xDD\xA4\x83\x87\xA2\xE8\x18\x81OEW\xD6\x12"
-      expect(args[2]["channel"]).to eq "0x0000000000bd9dcfda5c60697039e2b3b28b079b"
-      expect(args[2]["index"]).to eq 1
-      expect(args[2]["fromChainId"]).to eq 421613
-      expect(args[2]["from"]).to eq "0x0f14341a7f464320319025540e8fe48ad0fe5aec"
-      expect(args[2]["toChainId"]).to eq 43
-      expect(args[2]["to"]).to eq "0x0000000000bd9dcfda5c60697039e2b3b28b079b"
+      expect(args[2][0]).to eq "0x0000000000bd9dcfda5c60697039e2b3b28b079b"
+      expect(args[2][1]).to eq 1
+      expect(args[2][2]).to eq 421613
+      expect(args[2][3]).to eq "0x0f14341a7f464320319025540e8fe48ad0fe5aec"
+      expect(args[2][4]).to eq 43
+      expect(args[2][5]).to eq "0x0000000000bd9dcfda5c60697039e2b3b28b079b"
       expect(kwargs[:msgHash]).to eq "\xF6T\xC1~\xA8\x91\b\xD7\x18>\xAF1\xC7b\xFE\f\x12]Gj\xA8\x13\t8\xD8\xA1\x89S\a\xB7\xDBZ"
       expect(kwargs[:root]).to eq "\xFC*\a\xBA\xE9\xB7]Z\x81z\xA5\xFFu-&=!2\x86\xDD\xA4\x83\x87\xA2\xE8\x18\x81OEW\xD6\x12"
-      expect(kwargs[:message]["channel"]).to eq "0x0000000000bd9dcfda5c60697039e2b3b28b079b"
-      expect(kwargs[:message]["index"]).to eq 1
-      expect(kwargs[:message]["fromChainId"]).to eq 421613
-      expect(kwargs[:message]["from"]).to eq "0x0f14341a7f464320319025540e8fe48ad0fe5aec"
-      expect(kwargs[:message]["toChainId"]).to eq 43
-      expect(kwargs[:message]["to"]).to eq "0x0000000000bd9dcfda5c60697039e2b3b28b079b"
+      expect(kwargs[:message][0]).to eq "0x0000000000bd9dcfda5c60697039e2b3b28b079b"
+      expect(kwargs[:message][1]).to eq 1
+      expect(kwargs[:message][2]).to eq 421613
+      expect(kwargs[:message][3]).to eq "0x0f14341a7f464320319025540e8fe48ad0fe5aec"
+      expect(kwargs[:message][4]).to eq 43
+      expect(kwargs[:message][5]).to eq "0x0000000000bd9dcfda5c60697039e2b3b28b079b"
     end
   end
 

--- a/spec/eth/abi/type_spec.rb
+++ b/spec/eth/abi/type_spec.rb
@@ -28,7 +28,6 @@ describe Abi::Type do
       expect { Abi::Type.parse "bool8" }.to raise_error Abi::Type::ParseError
       expect { Abi::Type.parse "decimal" }.to raise_error Abi::Type::ParseError
 
-      expect { Abi::Type.parse "int" }.to raise_error Abi::Type::ParseError
       expect { Abi::Type.parse "int2" }.to raise_error Abi::Type::ParseError
       expect { Abi::Type.parse "int20" }.to raise_error Abi::Type::ParseError
       expect { Abi::Type.parse "int512" }.to raise_error Abi::Type::ParseError

--- a/spec/eth/abi_spec.rb
+++ b/spec/eth/abi_spec.rb
@@ -131,15 +131,44 @@ describe Abi do
     end
 
     it "passes ethersjs test cases" do
-      pending("https://github.com/q9f/eth.rb/issues/102")
+      normalize = lambda do |val, type|
+        t = Eth::Abi::Type.parse(type)
+        if t.dimensions.any?
+          val.map { |v| normalize.call(v, t.nested_sub) }
+        elsif t.base_type == "tuple"
+          val.zip(t.components).map { |v, comp| normalize.call(v, comp) }
+        elsif %w[uint int].include?(t.base_type)
+          val.is_a?(String) ? Integer(val) : val
+        elsif %w[ureal real fixed ufixed].include?(t.base_type)
+          val.is_a?(String) ? val.to_f : val
+        elsif t.base_type == "address"
+          val.is_a?(String) ? val.downcase : val
+        elsif t.base_type == "bytes"
+          if val.is_a?(String)
+            if Util.prefixed?(val) || (!t.sub_type.empty? && val.size == t.sub_type.to_i * 2 && Util.hex?(val))
+              Util.hex_to_bin(val)
+            else
+              val.codepoints.pack("C*")
+            end
+          else
+            val
+          end
+        elsif t.base_type == "string"
+          val.is_a?(String) ? val.force_encoding(Encoding::UTF_8) : val
+        else
+          val
+        end
+      end
+
       ethers_abi_tests.each do |test|
         types = test["type"]
-        args = test["value"]
+        args = normalize.call(test["value"], types)
         result = test["encoded"]
-        encoded = Abi.encode types, args
-        expect(Util.bin_to_hex encoded).to eq result
+        encoded = Abi.encode [types], [args]
+        expect(Util.prefix_hex(Util.bin_to_hex encoded)).to eq result
         expect(encoded).to eq Util.hex_to_bin result
-        decoded = Abi.decode types, result
+        decoded = Abi.decode([types], result).first
+        decoded = normalize.call(decoded, types)
         expect(decoded).to eq args
       end
     end
@@ -395,13 +424,11 @@ describe Abi do
       types = ["uint256", "(uint256,string)"]
       args = [1234, [5678, "Hello World"]]
       data = Util.hex_to_bin "00000000000000000000000000000000000000000000000000000000000004d20000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000162e0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000b48656c6c6f20576f726c64000000000000000000000000000000000000000000"
-      pending("https://github.com/q9f/eth.rb/issues/102")
       assert(data, types, args)
 
       types = ["uint256", "(address,uint256)[]", "string"]
-      args = [66, [["18a475d6741215709ed6cc5f4d064732379b5a58", 1]], "QmWBiSE9ByR6vrx4hvrjqS3SG5r6wE4SRq7CP2RVpafZWV"]
+      args = [66, [["0x18a475d6741215709ed6cc5f4d064732379b5a58", 1]], "QmWBiSE9ByR6vrx4hvrjqS3SG5r6wE4SRq7CP2RVpafZWV"]
       data = Util.hex_to_bin "0000000000000000000000000000000000000000000000000000000000000042000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000100000000000000000000000018a475d6741215709ed6cc5f4d064732379b5a580000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002e516d57426953453942795236767278346876726a71533353473572367745345352713743503252567061665a5756000000000000000000000000000000000000"
-      pending("https://github.com/q9f/eth.rb/issues/102")
       assert(data, types, args)
     end
   end

--- a/spec/eth/abi_spec.rb
+++ b/spec/eth/abi_spec.rb
@@ -131,7 +131,7 @@ describe Abi do
     end
 
     it "passes ethersjs test cases" do
-      pending("https://github.com/q9f/eth.rb/issues/102")
+      pending("https://github.com/q9f/eth.rb/issues/372")
       normalize = lambda do |val, type|
         t = Eth::Abi::Type.parse(type)
         if t.dimensions.any?

--- a/spec/eth/abi_spec.rb
+++ b/spec/eth/abi_spec.rb
@@ -131,6 +131,7 @@ describe Abi do
     end
 
     it "passes ethersjs test cases" do
+      pending("https://github.com/q9f/eth.rb/issues/102")
       normalize = lambda do |val, type|
         t = Eth::Abi::Type.parse(type)
         if t.dimensions.any?


### PR DESCRIPTION
- allow tuple ABI encoding with array args and handle nested tuples
- support decoding arrays of tuples and nested dynamic components
- parse canonical tuple syntax
- coerce numeric strings for integer/fixed types and enable ethers.js vectors
- guard decoder offsets for malformed tuple data
- fix #102 