### PR TITLE
Inform user for missing key

### DIFF
--- a/lib/eth/abi/encoder.rb
+++ b/lib/eth/abi/encoder.rb
@@ -206,7 +206,7 @@ module Eth
             dynamic_values << dynamic_value
             dynamic_offset += dynamic_value.size
           else
-            offsets_and_static_values << type(component_type, arg.is_a?(Array) ? arg[i] : arg[component_type.name])
+            offsets_and_static_values << type(component_type, arg.is_a?(Array) ? arg[i] : arg.fetch(component_type.name))
           end
         end
 


### PR DESCRIPTION
The original version will silently set the parameter to nil and will cause error in the future.