### PR TITLE
feat: use httpx for http requests (#377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.5.16]
+### Changed
+* Replace Net::HTTP with HTTPX for HTTP/2 support and persistent connections [#377](https://github.com/q9f/eth.rb/issues/377)
+
 ## [0.5.15]
 ### Added
 * Implement EIP712 array encoding [#361](https://github.com/q9f/eth.rb/pull/361)

--- a/eth.gemspec
+++ b/eth.gemspec
@@ -57,4 +57,7 @@ Gem::Specification.new do |spec|
 
   # bls12-381 for BLS signatures and pairings
   spec.add_dependency "bls12-381", "~> 0.3"
+
+  # httpx for HTTP/2 and persistent connections
+  spec.add_dependency "httpx", "~> 1.6"
 end

--- a/lib/eth/client/http.rb
+++ b/lib/eth/client/http.rb
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "net/http"
+require "uri"
+require "httpx"
 
 # Provides the {Eth} module.
 module Eth
@@ -57,6 +58,7 @@ module Eth
       else
         @uri = uri
       end
+      @client = HTTPX.plugin(:persistent).with(headers: { "Content-Type" => "application/json" })
     end
 
     # Sends an RPC request to the connected HTTP client.
@@ -64,13 +66,8 @@ module Eth
     # @param payload [Hash] the RPC request parameters.
     # @return [String] a JSON-encoded response.
     def send_request(payload)
-      http = Net::HTTP.new(@host, @port)
-      http.use_ssl = @ssl
-      header = { "Content-Type" => "application/json" }
-      request = Net::HTTP::Post.new(@uri, header)
-      request.body = payload
-      response = http.request(request)
-      response.body
+      response = @client.post(@uri, body: payload)
+      response.body.to_s
     end
   end
 


### PR DESCRIPTION
## Summary
- replace Net::HTTP with HTTPX to support HTTP/2 and persistent connections
- add HTTPX gem dependency
- document the HTTPX switch in the changelog

## Testing
- `bundle exec rspec` *(fails: Connection refused to 127.0.0.1:8545; solc compiler not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c00b7609ac832ba585b6894f316ae6