### PR TITLE
Add event signature lookup and decode_log to Contract

### DIFF
--- a/lib/eth/contract.rb
+++ b/lib/eth/contract.rb
@@ -45,6 +45,10 @@ module Eth
       @bin = bin
       @abi = abi
       @constructor_inputs, @functions, @events, @errors = parse_abi(abi)
+      @sigs2events = {}
+      @events.each do |event|
+        @sigs2events[event.signature] = event
+      end
     end
 
     # Creates a contract wrapper from a Solidity file.
@@ -176,6 +180,13 @@ module Eth
       Eth::Contract.send(:remove_const, class_name) if Eth::Contract.const_defined?(class_name, false)
       Eth::Contract.const_set(class_name, class_methods)
       @class_object = class_methods
+    end
+
+    def decode_log(topics, data)
+      sig = topics[0]
+      event = @sigs2events[sig]
+      raise ArgumentError, "this event does not exist!" if event.nil?
+      event.decode_params(topics, data)
     end
 
     private

--- a/lib/eth/contract.rb
+++ b/lib/eth/contract.rb
@@ -172,6 +172,7 @@ module Eth
         def_delegator :parent, :function
         def_delegator :parent, :error
         def_delegator :parent, :decode_error
+        def_delegator :parent, :decode_log
         def_delegator :parent, :constructor_inputs
         define_method :parent do
           parent
@@ -182,8 +183,16 @@ module Eth
       @class_object = class_methods
     end
 
+    # Decodes an event log by looking up the event signature in the
+    # contract ABI.
+    #
+    # @param topics [Array<String>] the list of log topics, including the
+    #   event selector.
+    # @param data [String] the log data containing non-indexed parameters.
+    # @return [Hash] a hash of decoded event parameters.
+    # @raise [ArgumentError] if the event is not part of the contract ABI.
     def decode_log(topics, data)
-      sig = topics[0]
+      sig = Eth::Util.remove_hex_prefix(topics[0])
       event = @sigs2events[sig]
       raise ArgumentError, "this event does not exist!" if event.nil?
       event.decode_params(topics, data)

--- a/spec/eth/contract_spec.rb
+++ b/spec/eth/contract_spec.rb
@@ -118,6 +118,39 @@ describe Contract do
     end
   end
 
+  describe "#decode_log" do
+    let(:erc20_abi) { JSON.parse(File.read("spec/fixtures/abi/ERC20.json")) }
+    subject(:erc20) { Contract.from_abi(name: "ERC20", abi: erc20_abi, address: addr) }
+
+    let(:topics) do
+      [
+        # Transfer event signature
+        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+        # from
+        "0x00000000000000000000000071660c4005ba85c37ccec55d0c4493e66fe775d3",
+        # to
+        "0x000000000000000000000000639671019ddd8ec28d35113d8d1c5f1bbfd7e0be",
+      ]
+    end
+    let(:data) { "0x00000000000000000000000000000000000000000000000000000002540be400" }
+
+    it "decodes event logs by signature" do
+      decoded = erc20.decode_log(topics, data)
+      expect(decoded["from"]).to eq "0x71660c4005ba85c37ccec55d0c4493e66fe775d3"
+      expect(decoded["to"]).to eq "0x639671019ddd8ec28d35113d8d1c5f1bbfd7e0be"
+      expect(decoded["value"]).to eq 10000000000
+    end
+
+    it "accepts topics without hex prefix" do
+      decoded = erc20.decode_log(topics.map { |t| Eth::Util.remove_hex_prefix(t) }, data)
+      expect(decoded["from"]).to eq "0x71660c4005ba85c37ccec55d0c4493e66fe775d3"
+    end
+
+    it "raises for unknown event signatures" do
+      expect { erc20.decode_log(["0x#{"00" * 32}"], "0x") }.to raise_error ArgumentError, "this event does not exist!"
+    end
+  end
+
   describe "#function" do
     it "finds function by name" do
       expect(dummy_contract.function("set").name).to eq("set")


### PR DESCRIPTION
## Summary

Adds an event signature index to `Eth::Contract` and a `decode_log` convenience method for decoding event logs.

- Builds a `@sigs2events` map (event signature => event object) at initialization for O(1) lookup
- New `Contract#decode_log(topics, data)` method: looks up the event by `topics[0]` and delegates to `Event#decode_params`
- Raises `ArgumentError` when the event signature is not part of the contract ABI

## Example

```ruby
contract = Eth::Contract.from_abi(name: "MyToken", bin: bin, abi: abi)
params = contract.decode_log(receipt["logs"][0]["topics"], receipt["logs"][0]["data"])
```